### PR TITLE
feat: add resumable runtime

### DIFF
--- a/src/uipath/runtime/__init__.py
+++ b/src/uipath/runtime/__init__.py
@@ -8,6 +8,12 @@ from uipath.runtime.base import (
     UiPathStreamOptions,
 )
 from uipath.runtime.context import UiPathRuntimeContext
+from uipath.runtime.debug.breakpoint import UiPathBreakpointResult
+from uipath.runtime.debug.bridge import UiPathDebugBridgeProtocol
+from uipath.runtime.debug.exception import UiPathDebugQuitError
+from uipath.runtime.debug.runtime import (
+    UiPathDebugRuntime,
+)
 from uipath.runtime.events import UiPathRuntimeEvent
 from uipath.runtime.factory import (
     UiPathRuntimeCreatorProtocol,
@@ -15,12 +21,20 @@ from uipath.runtime.factory import (
     UiPathRuntimeScannerProtocol,
 )
 from uipath.runtime.result import (
-    UiPathApiTrigger,
-    UiPathBreakpointResult,
-    UiPathResumeTrigger,
-    UiPathResumeTriggerType,
     UiPathRuntimeResult,
     UiPathRuntimeStatus,
+)
+from uipath.runtime.resumable.protocols import (
+    UiPathResumableStorageProtocol,
+    UiPathResumeTriggerProtocol,
+)
+from uipath.runtime.resumable.runtime import (
+    UiPathResumableRuntime,
+)
+from uipath.runtime.resumable.trigger import (
+    UiPathApiTrigger,
+    UiPathResumeTrigger,
+    UiPathResumeTriggerType,
 )
 
 __all__ = [
@@ -35,9 +49,15 @@ __all__ = [
     "UiPathRuntimeResult",
     "UiPathRuntimeStatus",
     "UiPathRuntimeEvent",
-    "UiPathBreakpointResult",
+    "UiPathResumableStorageProtocol",
+    "UiPathResumeTriggerProtocol",
     "UiPathApiTrigger",
     "UiPathResumeTrigger",
     "UiPathResumeTriggerType",
+    "UiPathResumableRuntime",
+    "UiPathDebugQuitError",
+    "UiPathDebugBridgeProtocol",
+    "UiPathDebugRuntime",
+    "UiPathBreakpointResult",
     "UiPathStreamNotSupportedError",
 ]

--- a/src/uipath/runtime/debug/__init__.py
+++ b/src/uipath/runtime/debug/__init__.py
@@ -1,5 +1,6 @@
 """Initialization module for the debug package."""
 
+from uipath.runtime.debug.breakpoint import UiPathBreakpointResult
 from uipath.runtime.debug.bridge import UiPathDebugBridgeProtocol
 from uipath.runtime.debug.exception import (
     UiPathDebugQuitError,
@@ -10,4 +11,5 @@ __all__ = [
     "UiPathDebugQuitError",
     "UiPathDebugBridgeProtocol",
     "UiPathDebugRuntime",
+    "UiPathBreakpointResult",
 ]

--- a/src/uipath/runtime/debug/breakpoint.py
+++ b/src/uipath/runtime/debug/breakpoint.py
@@ -1,0 +1,20 @@
+"""Module defining the result for execution suspended at a breakpoint."""
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from uipath.runtime.result import UiPathRuntimeResult, UiPathRuntimeStatus
+
+
+class UiPathBreakpointResult(UiPathRuntimeResult):
+    """Result for execution suspended at a breakpoint."""
+
+    # Force status to always be SUSPENDED
+    status: UiPathRuntimeStatus = Field(
+        default=UiPathRuntimeStatus.SUSPENDED, frozen=True
+    )
+    breakpoint_node: str  # Which node the breakpoint is at
+    breakpoint_type: Literal["before", "after"]  # Before or after the node
+    current_state: dict[str, Any] | Any  # Current workflow state at breakpoint
+    next_nodes: list[str]  # Which node(s) will execute next

--- a/src/uipath/runtime/debug/bridge.py
+++ b/src/uipath/runtime/debug/bridge.py
@@ -2,11 +2,11 @@
 
 from typing import Any, Literal, Protocol
 
-from uipath.runtime import (
-    UiPathBreakpointResult,
+from uipath.runtime.debug.breakpoint import UiPathBreakpointResult
+from uipath.runtime.events import UiPathRuntimeStateEvent
+from uipath.runtime.result import (
     UiPathRuntimeResult,
 )
-from uipath.runtime.events import UiPathRuntimeStateEvent
 
 
 class UiPathDebugBridgeProtocol(Protocol):

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -3,18 +3,23 @@
 import logging
 from typing import Any, Optional
 
-from uipath.runtime import (
-    UiPathBreakpointResult,
+from uipath.runtime.base import (
     UiPathExecuteOptions,
     UiPathRuntimeProtocol,
-    UiPathRuntimeResult,
-    UiPathRuntimeStatus,
     UiPathStreamNotSupportedError,
     UiPathStreamOptions,
 )
-from uipath.runtime.debug import UiPathDebugBridgeProtocol, UiPathDebugQuitError
+from uipath.runtime.debug import (
+    UiPathBreakpointResult,
+    UiPathDebugBridgeProtocol,
+    UiPathDebugQuitError,
+)
 from uipath.runtime.events import (
     UiPathRuntimeStateEvent,
+)
+from uipath.runtime.result import (
+    UiPathRuntimeResult,
+    UiPathRuntimeStatus,
 )
 from uipath.runtime.schema import UiPathRuntimeSchema
 

--- a/src/uipath/runtime/resumable/__init__.py
+++ b/src/uipath/runtime/resumable/__init__.py
@@ -1,0 +1,23 @@
+"""Module for resumable runtime features."""
+
+from uipath.runtime.resumable.protocols import (
+    UiPathResumableStorageProtocol,
+    UiPathResumeTriggerCreatorProtocol,
+    UiPathResumeTriggerProtocol,
+    UiPathResumeTriggerReaderProtocol,
+)
+from uipath.runtime.resumable.trigger import (
+    UiPathApiTrigger,
+    UiPathResumeTrigger,
+    UiPathResumeTriggerType,
+)
+
+__all__ = [
+    "UiPathResumableStorageProtocol",
+    "UiPathResumeTriggerCreatorProtocol",
+    "UiPathResumeTriggerReaderProtocol",
+    "UiPathResumeTriggerProtocol",
+    "UiPathResumeTrigger",
+    "UiPathResumeTriggerType",
+    "UiPathApiTrigger",
+]

--- a/src/uipath/runtime/resumable/protocols.py
+++ b/src/uipath/runtime/resumable/protocols.py
@@ -1,0 +1,84 @@
+"""Module defining the protocol for resume trigger storage."""
+
+from typing import Any, Optional, Protocol
+
+from uipath.runtime.resumable.trigger import UiPathResumeTrigger
+
+
+class UiPathResumableStorageProtocol(Protocol):
+    """Protocol for storing and retrieving resume triggers."""
+
+    async def save_trigger(self, trigger: UiPathResumeTrigger) -> None:
+        """Save a resume trigger to storage.
+
+        Args:
+            trigger: The resume trigger to persist
+
+        Raises:
+            Exception: If storage operation fails
+        """
+        ...
+
+    async def get_latest_trigger(self) -> Optional[UiPathResumeTrigger]:
+        """Retrieve the most recent resume trigger from storage.
+
+        Returns:
+            The latest resume trigger, or None if no triggers exist
+
+        Raises:
+            Exception: If retrieval operation fails
+        """
+        ...
+
+
+class UiPathResumeTriggerCreatorProtocol(Protocol):
+    """Protocol for creating resume triggers from suspend values."""
+
+    async def create_trigger(self, suspend_value: Any) -> UiPathResumeTrigger:
+        """Create a resume trigger from a suspend value.
+
+        Args:
+            suspend_value: The value that caused the suspension.
+                Can be UiPath models (CreateAction, InvokeProcess, etc.),
+                strings, or any other value that needs HITL processing.
+
+        Returns:
+            UiPathResumeTrigger ready to be persisted
+
+        Raises:
+            UiPathRuntimeError: If trigger creation fails
+        """
+        ...
+
+
+class UiPathResumeTriggerReaderProtocol(Protocol):
+    """Protocol for reading resume triggers and converting them to runtime input."""
+
+    async def read_trigger(self, trigger: UiPathResumeTrigger) -> Optional[Any]:
+        """Read a resume trigger and convert it to runtime-compatible input.
+
+        This method retrieves data from UiPath services (Actions, Jobs, API)
+        based on the trigger type and returns it in a format that the
+        runtime can use to resume execution.
+
+        Args:
+            trigger: The resume trigger to read
+
+        Returns:
+            The data retrieved from UiPath services, ready to be used
+            as resume input. Format depends on trigger type:
+            - ACTION: Action data (possibly with escalation processing)
+            - JOB: Job output data
+            - API: API payload
+            Returns None if no data is available.
+
+        Raises:
+            UiPathRuntimeError: If reading fails or job failed
+        """
+        ...
+
+
+class UiPathResumeTriggerProtocol(
+    UiPathResumeTriggerCreatorProtocol, UiPathResumeTriggerReaderProtocol, Protocol
+):
+    """Protocol combining both creation and reading of resume triggers."""

--- a/src/uipath/runtime/resumable/runtime.py
+++ b/src/uipath/runtime/resumable/runtime.py
@@ -1,0 +1,159 @@
+"""Resumable runtime protocol and implementation."""
+
+import logging
+from typing import Any, AsyncGenerator, Optional
+
+from uipath.runtime.base import (
+    UiPathExecuteOptions,
+    UiPathRuntimeProtocol,
+    UiPathStreamOptions,
+)
+from uipath.runtime.events import UiPathRuntimeEvent
+from uipath.runtime.result import UiPathRuntimeResult, UiPathRuntimeStatus
+from uipath.runtime.resumable.protocols import (
+    UiPathResumableStorageProtocol,
+    UiPathResumeTriggerProtocol,
+)
+from uipath.runtime.schema import UiPathRuntimeSchema
+
+logger = logging.getLogger(__name__)
+
+
+class UiPathResumableRuntime:
+    """Generic runtime wrapper that adds resume trigger management to any runtime.
+
+    This class wraps any UiPathRuntimeProtocol implementation and handles:
+    - Detecting suspensions in execution results
+    - Creating and persisting resume triggers via handler
+    - Restoring resume triggers from storage on resume
+    - Passing through all other runtime operations unchanged
+    """
+
+    def __init__(
+        self,
+        delegate: UiPathRuntimeProtocol,
+        storage: UiPathResumableStorageProtocol,
+        trigger_manager: UiPathResumeTriggerProtocol,
+    ):
+        """Initialize the resumable runtime wrapper.
+
+        Args:
+            delegate: The underlying runtime to wrap
+            storage: Storage for persisting/retrieving resume triggers
+            trigger_manager: Manager for creating and reading resume triggers
+        """
+        self.delegate = delegate
+        self.storage = storage
+        self.trigger_manager = trigger_manager
+
+    async def execute(
+        self,
+        input: Optional[dict[str, Any]] = None,
+        options: Optional[UiPathExecuteOptions] = None,
+    ) -> UiPathRuntimeResult:
+        """Execute with resume trigger handling.
+
+        Args:
+            input: Input data for execution
+            options: Execution options including resume flag
+
+        Returns:
+            Execution result, potentially with resume trigger attached
+        """
+        # If resuming, restore trigger from storage
+        if options and options.resume:
+            input = await self._restore_resume_input(input)
+
+        # Execute the delegate
+        result = await self.delegate.execute(input, options=options)
+
+        # If suspended, create and persist trigger
+        await self._handle_suspension(result)
+
+        return result
+
+    async def stream(
+        self,
+        input: Optional[dict[str, Any]] = None,
+        options: Optional[UiPathStreamOptions] = None,
+    ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
+        """Stream with resume trigger handling.
+
+        Args:
+            input: Input data for execution
+            options: Stream options including resume flag
+
+        Yields:
+            Runtime events during execution, final event is UiPathRuntimeResult
+        """
+        # If resuming, restore trigger from storage
+        if options and options.resume:
+            input = await self._restore_resume_input(input)
+
+        # Stream from delegate
+        final_result: Optional[UiPathRuntimeResult] = None
+        async for event in self.delegate.stream(input, options=options):
+            yield event
+
+            # Capture final result
+            if isinstance(event, UiPathRuntimeResult):
+                final_result = event
+
+        # If suspended, create and persist trigger
+        if final_result:
+            await self._handle_suspension(final_result)
+
+    async def _restore_resume_input(
+        self, input: Optional[dict[str, Any]]
+    ) -> Optional[dict[str, Any]]:
+        """Restore resume input from storage if not provided.
+
+        Args:
+            input: User-provided input (takes precedence)
+
+        Returns:
+            Input to use for resume, either provided or from storage
+        """
+        # If user provided explicit input, use it
+        if input:
+            return input
+
+        # Otherwise, fetch from storage
+        trigger = await self.storage.get_latest_trigger()
+        if not trigger:
+            return None
+
+        # Read trigger data via trigger_manager
+        resume_data = await self.trigger_manager.read_trigger(trigger)
+
+        return resume_data
+
+    async def _handle_suspension(self, result: UiPathRuntimeResult) -> None:
+        """Create and persist resume trigger if execution was suspended.
+
+        Args:
+            result: The execution result to check for suspension
+        """
+        # Only handle suspensions
+        if result.status != UiPathRuntimeStatus.SUSPENDED:
+            return
+
+        # Check if trigger already exists in result
+        if result.resume:
+            await self.storage.save_trigger(result.resume)
+            return
+
+        if result.output:
+            trigger = await self.trigger_manager.create_trigger(result.output)
+
+            result.resume = trigger
+
+            await self.storage.save_trigger(trigger)
+
+    async def get_schema(self) -> UiPathRuntimeSchema:
+        """Passthrough schema from delegate runtime."""
+        return await self.delegate.get_schema()
+
+    async def dispose(self) -> None:
+        """Cleanup resources for both wrapper and delegate."""
+        await self.delegate.dispose()

--- a/src/uipath/runtime/resumable/trigger.py
+++ b/src/uipath/runtime/resumable/trigger.py
@@ -1,0 +1,42 @@
+"""Module defining resume trigger types and data models."""
+
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class UiPathResumeTriggerType(str, Enum):
+    """Constants representing different types of resume job triggers in the system."""
+
+    NONE = "None"
+    QUEUE_ITEM = "QueueItem"
+    JOB = "Job"
+    ACTION = "Task"
+    TIMER = "Timer"
+    INBOX = "Inbox"
+    API = "Api"
+
+
+class UiPathApiTrigger(BaseModel):
+    """API resume trigger request."""
+
+    inbox_id: Optional[str] = Field(default=None, alias="inboxId")
+    request: Any = None
+
+    model_config = {"populate_by_name": True}
+
+
+class UiPathResumeTrigger(BaseModel):
+    """Information needed to resume execution."""
+
+    trigger_type: UiPathResumeTriggerType = Field(
+        default=UiPathResumeTriggerType.API, alias="triggerType"
+    )
+    item_key: Optional[str] = Field(default=None, alias="itemKey")
+    api_resume: Optional[UiPathApiTrigger] = Field(default=None, alias="apiResume")
+    folder_path: Optional[str] = Field(default=None, alias="folderPath")
+    folder_key: Optional[str] = Field(default=None, alias="folderKey")
+    payload: Optional[Any] = Field(default=None, alias="interruptObject")
+
+    model_config = {"populate_by_name": True}


### PR DESCRIPTION
## Description

This PR introduces a generic resumable runtime system that enables any UiPath runtime to handle execution suspension and resumption. The system manages HITL scenarios by persisting resume triggers when execution suspends and restoring them when resuming.

- `UiPathResumableStorageProtocol` - Persists and retrieves resume triggers metadata
- `UiPathResumeTriggerProtocol` - Creates triggers (api/actions/jobs) from interrupts and reads back the completion payload
- `UiPathResumableRuntime` - Wraps any runtime to add resumable capabilities

## Usage Examples

### Basic Setup

```python
from uipath.runtime import UiPathResumableRuntime
from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver

memory = AsyncSqliteSaver.from_conn_string(":memory:")
base_runtime = LangGraphRuntime(graph, memory)

# Create storage and handler
storage = LangGraphResumeTriggerStorage(memory)
trigger_manager= UiPathPlatformResumeTriggerManager()

# Wrap with resumable capabilities
resumable_runtime = UiPathResumableRuntime(
    delegate=base_runtime,
    storage=storage,
    trigger_manager=trigger_manager,
)
```
### Execute with Suspension
```python
from uipath.models import CreateAction
from langgraph.types import interrupt

# In your graph node
def approval_node(state):
    # Request human approval
    action = CreateAction(
        title="Approve Budget Request",
        data={"amount": state["budget"]},
        app_name="Approvals",
    )
    # This will suspend execution
    interrupt(action)

# Execute
result = await resumable_runtime.execute(input={"budget": 50000})

# Result will be SUSPENDED with resume trigger
assert result.status == UiPathRuntimeStatus.SUSPENDED
assert result.resume.trigger_type == UiPathResumeTriggerType.ACTION
print(f"Waiting for action: {result.resume.item_key}")
```

### Resume Execution

```python
from uipath.runtime import UiPathExecuteOptions

# Later, when the action is completed...
options = UiPathExecuteOptions(resume=True)

# Resume picks up the trigger from storage automatically
result = await resumable_runtime.execute(options=options)

# Execution continues from where it left off
assert result.status == UiPathRuntimeStatus.SUCCESSFUL
print(f"Final output: {result.output}")
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.0.8.dev1000160067",

  # Any version from PR
  "uipath-runtime>=0.0.8.dev1000160000,<0.0.8.dev1000170000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```