### PR TITLE
fix: add polling for resumable runtimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.0.8"
+version = "0.0.9"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/result.py
+++ b/src/uipath/runtime/result.py
@@ -23,7 +23,7 @@ class UiPathRuntimeResult(UiPathRuntimeEvent):
 
     output: Optional[Union[dict[str, Any], BaseModel]] = None
     status: UiPathRuntimeStatus = UiPathRuntimeStatus.SUCCESSFUL
-    resume: Optional[UiPathResumeTrigger] = None
+    trigger: Optional[UiPathResumeTrigger] = None
     error: Optional[UiPathErrorContract] = None
 
     event_type: UiPathRuntimeEventType = Field(
@@ -44,8 +44,8 @@ class UiPathRuntimeResult(UiPathRuntimeEvent):
             "status": self.status,
         }
 
-        if self.resume:
-            result["resume"] = self.resume.model_dump(by_alias=True)
+        if self.trigger:
+            result["resume"] = self.trigger.model_dump(by_alias=True)
 
         if self.error:
             result["error"] = self.error.model_dump()

--- a/src/uipath/runtime/resumable/runtime.py
+++ b/src/uipath/runtime/resumable/runtime.py
@@ -139,14 +139,14 @@ class UiPathResumableRuntime:
             return
 
         # Check if trigger already exists in result
-        if result.resume:
-            await self.storage.save_trigger(result.resume)
+        if result.trigger:
+            await self.storage.save_trigger(result.trigger)
             return
 
         if result.output:
             trigger = await self.trigger_manager.create_trigger(result.output)
 
-            result.resume = trigger
+            result.trigger = trigger
 
             await self.storage.save_trigger(trigger)
 

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Add polling support for suspended executions in debug runtime

### Changes
- Add trigger polling to `UiPathDebugRuntime` when delegate is `UiPathResumableRuntime`
- Poll resume triggers at configurable intervals until data is available: `trigger_poll_interval` parameter (default: 5.0s, set to 0 to disable)
- Auto-resume execution when trigger data becomes ready
- Emit polling events (`<polling>`, `<suspended>`, `<resumed>`) to debug bridge for visibility
- Support quit during polling via race between sleep and debug bridge signals

### Behavior
When execution suspends with a resume trigger (e.g., HITL actions), the debug runtime now:
1. Emits suspension state to debug bridge
2. Polls trigger using `trigger_manager.read_trigger()` 
3. Waits for poll interval OR quit command (whichever comes first)
4. Auto-resumes execution when data is available
5. Continues streaming events through the debug bridge



## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.0.9.dev1000170072",

  # Any version from PR
  "uipath-runtime>=0.0.9.dev1000170000,<0.0.9.dev1000180000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```