### PR TITLE
fix: handle early debug quit

### DIFF
--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -121,6 +121,10 @@ class UiPathDebugRuntime:
             logger.warning(
                 "Initial resume wait timed out after 60s, assuming debug bridge disconnected"
             )
+            yield UiPathRuntimeResult(status=UiPathRuntimeStatus.FAULTED)
+            return
+        except UiPathDebugQuitError:
+            logger.info("Debug session quit by user before execution started")
             yield UiPathRuntimeResult(status=UiPathRuntimeStatus.SUCCESSFUL)
             return
 


### PR DESCRIPTION
## Description

This PR fixes the handling of early debug quit scenarios by adding exception handlers for both timeout and quit conditions during the initial resume wait. Previously, if a user quit the debug session or if the initial resume timed out before execution started, these cases were not properly handled.

## Key Changes
- Added `TimeoutError` handler that yields a `FAULTED` status result when the initial resume wait times out after 60 seconds
- Added `UiPathDebugQuitError` handler that yields a `SUCCESSFUL` status result when a user quits the debug session before execution starts