### PR TITLE
fix: add runtime_id to factory new_runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ from uipath.runtime import (
 )
 
 class MyRuntimeFactory:
-    async def new_runtime(self, entrypoint: str) -> UiPathRuntimeProtocol:
+    async def new_runtime(self, entrypoint: str, runtime_id: str) -> UiPathRuntimeProtocol:
         return MyRuntime()
 
     def discover_runtimes(self) -> list[UiPathRuntimeProtocol]:
@@ -173,7 +173,7 @@ class MyRuntimeFactory:
 
 
 factory = MyRuntimeFactory()
-runtime = await factory.new_runtime("example")
+runtime = await factory.new_runtime("example", "id")
 
 result = await runtime.execute()
 print(result.output)  # {'message': 'Hello from MyRuntime'}
@@ -343,7 +343,7 @@ class OrchestratorRuntime:
 
         for i, child_input in enumerate(child_inputs):
             # Use the factory to create a new child runtime
-            child_runtime = await self.factory.new_runtime(entrypoint=f"child-{i}")
+            child_runtime = await self.factory.new_runtime(entrypoint=f"child-{i}", runtime_id=f"child-{i}")
 
             # Wrap child runtime with tracing + logs
             execution_id = f"child-{i}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.0.14"
+version = "0.0.15"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/factory.py
+++ b/src/uipath/runtime/factory.py
@@ -20,7 +20,9 @@ class UiPathRuntimeScannerProtocol(Protocol):
 class UiPathRuntimeCreatorProtocol(Protocol):
     """Protocol for creating a UiPath runtime given an entrypoint."""
 
-    async def new_runtime(self, entrypoint: str) -> UiPathRuntimeProtocol:
+    async def new_runtime(
+        self, entrypoint: str, runtime_id: str
+    ) -> UiPathRuntimeProtocol:
         """Create a new runtime instance."""
         ...
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -113,7 +113,9 @@ class UiPathTestRuntimeFactory:
     def __init__(self, runtime_class: type[UiPathRuntimeProtocol]):
         self.runtime_class = runtime_class
 
-    async def new_runtime(self, entrypoint: str) -> UiPathRuntimeProtocol:
+    async def new_runtime(
+        self, entrypoint: str, runtime_id: str
+    ) -> UiPathRuntimeProtocol:
         return self.runtime_class()
 
 
@@ -128,21 +130,21 @@ async def test_multiple_factories_same_executor():
     factory_c = UiPathTestRuntimeFactory(MockRuntimeC)
 
     # Execute runtime A
-    runtime_a = await factory_a.new_runtime(entrypoint="")
+    runtime_a = await factory_a.new_runtime(entrypoint="", runtime_id="runtime-a")
     execution_runtime_a = UiPathExecutionRuntime(
         runtime_a, trace_manager, "runtime-a-span", execution_id="exec-a"
     )
     result_a = await execution_runtime_a.execute({"input": "a"})
 
     # Execute runtime B
-    runtime_b = await factory_b.new_runtime(entrypoint="")
+    runtime_b = await factory_b.new_runtime(entrypoint="", runtime_id="runtime-b")
     execution_runtime_b = UiPathExecutionRuntime(
         runtime_b, trace_manager, "runtime-b-span", execution_id="exec-b"
     )
     result_b = await execution_runtime_b.execute({"input": "b"})
 
     # Execute runtime C with custom spans
-    runtime_c = await factory_c.new_runtime(entrypoint="")
+    runtime_c = await factory_c.new_runtime(entrypoint="", runtime_id="runtime-c")
     execution_runtime_c = UiPathExecutionRuntime(
         runtime_c, trace_manager, "runtime-c-span", execution_id="exec-c"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.14"
+version = "0.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR adds a required `runtime_id` parameter to the `new_runtime` method in the `UiPathRuntimeCreatorProtocol`