### PR TITLE
fix: add trace_manager to context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.0.20"
+version = "0.0.21"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
+from uipath.core.tracing import UiPathTraceManager
 
 from uipath.runtime.errors import (
     UiPathErrorCategory,
@@ -27,6 +28,7 @@ class UiPathRuntimeContext(BaseModel):
     entrypoint: str | None = None
     input: str | None = None
     resume: bool = False
+    command: str | None = None
     job_id: str | None = None
     tenant_id: str | None = None
     org_id: str | None = None
@@ -42,6 +44,7 @@ class UiPathRuntimeContext(BaseModel):
     logs_file: str | None = "execution.log"
     logs_min_level: str | None = "INFO"
     result: UiPathRuntimeResult | None = None
+    trace_manager: UiPathTraceManager | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.0.21.dev1000320100",

  # Any version from PR
  "uipath-runtime>=0.0.21.dev1000320000,<0.0.21.dev1000330000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```