### PR TITLE
fix: add metadata to graph nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.0.21"
+version = "0.0.22"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/schema.py
+++ b/src/uipath/runtime/schema.py
@@ -24,6 +24,9 @@ class UiPathRuntimeNode(BaseModel):
     subgraph: UiPathRuntimeGraph | None = Field(
         None, description="Nested subgraph if this node contains one"
     )
+    metadata: dict[str, Any] | None = Field(
+        None, description="Additional node metadata (e.g., model config, tool names)"
+    )
 
     model_config = COMMON_MODEL_SCHEMA
 

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.21"
+version = "0.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR adds a `metadata` field to graph nodes in the UiPath runtime schema to support storing additional node information such as model configurations and tool names. 