### PR TITLE
fix: graceful debug termination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.0.23"
+version = "0.1.0"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/debug/bridge.py
+++ b/src/uipath/runtime/debug/bridge.py
@@ -55,6 +55,10 @@ class UiPathDebugBridgeProtocol(Protocol):
         """Wait for resume command from debugger."""
         ...
 
+    async def wait_for_terminate(self) -> None:
+        """Wait until the user has requested to terminate debugging."""
+        ...
+
     def get_breakpoints(self) -> list[str] | Literal["*"]:
         """Get nodes to suspend execution at.
 

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.23"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR implements graceful debug termination by refactoring how the debug runtime handles quit requests during polling operations. The version is bumped from 0.0.23 to 0.1.0, indicating a minor version release.

- Introduces a new `wait_for_terminate()` method in the debug bridge protocol
- Refactors `_wait_with_quit_check()` to use the new termination method instead of `wait_for_resume()`
- Adjusts state update emission timing and simplifies error payload structure

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.1.0.dev1000360110",

  # Any version from PR
  "uipath-runtime>=0.1.0.dev1000360000,<0.1.0.dev1000370000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```