### PR TITLE
fix: reset input on breakpoint step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.1.1"
+version = "0.1.2"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -159,6 +159,9 @@ class UiPathDebugRuntime:
 
                             # Tell inner runtime we're resuming
                             debug_options.resume = True
+                            current_input = (
+                                None  # Resume with no new input (very important)
+                            )
 
                         except UiPathDebugQuitError:
                             final_result = UiPathRuntimeResult(

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR fixes a bug in the debug runtime where the input was not being properly reset when resuming from a breakpoint. The fix ensures that when execution resumes after hitting a breakpoint, no input is passed to the subsequent stream call, preventing unintended re-processing of the original input.