### PR TITLE
fix: add chat context ids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.2.2"
+version = "0.2.3"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/chat/runtime.py
+++ b/src/uipath/runtime/chat/runtime.py
@@ -72,8 +72,6 @@ class UiPathChatRuntime:
 
             yield event
 
-        await self.chat_bridge.disconnect()
-
     async def get_schema(self) -> UiPathRuntimeSchema:
         """Get schema from the delegate runtime."""
         return await self.delegate.get_schema()

--- a/tests/test_chat_runtime.py
+++ b/tests/test_chat_runtime.py
@@ -110,6 +110,8 @@ async def test_chat_runtime_streams_and_emits_messages():
 
     result = await chat_runtime.execute({})
 
+    await chat_runtime.dispose()
+
     # Result propagation
     assert isinstance(result, UiPathRuntimeResult)
     assert result.status == UiPathRuntimeStatus.SUCCESSFUL
@@ -148,6 +150,8 @@ async def test_chat_runtime_stream_yields_all_events():
     events = []
     async for event in chat_runtime.stream({}):
         events.append(event)
+
+    await chat_runtime.dispose()
 
     # Should have 2 message events + 1 final result
     assert len(events) == 3

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR adds support for chat context identifiers by introducing three new fields (`conversation_id`, `exchange_id`, `message_id`) to the runtime context, updating the configuration loading logic to read these from `fpsProperties`, and removing a `disconnect()` call from the chat runtime's streaming method. 

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.2.3.dev1000450149",

  # Any version from PR
  "uipath-runtime>=0.2.3.dev1000450000,<0.2.3.dev1000460000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```