### PR TITLE
fix: chat runtime results should be suspended

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UiPath Runtime
 
-[![PyPI downloads](https://img.shields.io/pypi/dm/uipath-runtime.svg)](https://pypi.org/project/uipath-runtime/)
 [![PyPI - Version](https://img.shields.io/pypi/v/uipath-runtime)](https://pypi.org/project/uipath-runtime/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/uipath-runtime.svg)](https://pypi.org/project/uipath-runtime/)
 [![Python versions](https://img.shields.io/pypi/pyversions/uipath-runtime.svg)](https://pypi.org/project/uipath-runtime/)
 
 Runtime abstractions and contracts for the UiPath Python SDK.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.2.4"
+version = "0.2.5"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/errors/exception.py
+++ b/src/uipath/runtime/errors/exception.py
@@ -1,5 +1,7 @@
 """Base exception class for UiPath runtime errors with structured error information."""
 
+from __future__ import annotations
+
 import sys
 import traceback
 from typing import Any
@@ -105,7 +107,7 @@ class UiPathRuntimeError(UiPathBaseRuntimeError):
     @classmethod
     def from_resume_trigger_error(
         cls, exc: UiPathFaultedTriggerError
-    ) -> "UiPathRuntimeError":
+    ) -> UiPathRuntimeError:
         """Create UiPathRuntimeError from UiPathFaultedTriggerError."""
         return cls(
             code=UiPathErrorCode.RESUME_TRIGGER_ERROR,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -114,7 +114,7 @@ async def test_chat_runtime_streams_and_emits_messages():
 
     # Result propagation
     assert isinstance(result, UiPathRuntimeResult)
-    assert result.status == UiPathRuntimeStatus.SUCCESSFUL
+    assert result.status == UiPathRuntimeStatus.SUSPENDED
     assert result.output == {"messages": ["Hello", "How are you?", "Goodbye"]}
 
     # Bridge lifecycle
@@ -158,6 +158,7 @@ async def test_chat_runtime_stream_yields_all_events():
     assert isinstance(events[0], UiPathRuntimeMessageEvent)
     assert isinstance(events[1], UiPathRuntimeMessageEvent)
     assert isinstance(events[2], UiPathRuntimeResult)
+    assert events[2].status == UiPathRuntimeStatus.SUSPENDED
 
     # Bridge methods called
     cast(AsyncMock, bridge.connect).assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR modifies the chat runtime to convert successful execution results to suspended status.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.2.5.dev1000470157",

  # Any version from PR
  "uipath-runtime>=0.2.5.dev1000470000,<0.2.5.dev1000480000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```