### PR TITLE
chore: add fps context properties for mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.2.7"
+version = "0.2.8"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -34,6 +34,8 @@ class UiPathRuntimeContext(BaseModel):
     conversation_id: str | None = None
     exchange_id: str | None = None
     message_id: str | None = None
+    mcp_server_id: str | None = None
+    mcp_server_slug: str | None = None
     tenant_id: str | None = None
     org_id: str | None = None
     folder_key: str | None = None
@@ -320,6 +322,8 @@ class UiPathRuntimeContext(BaseModel):
             "conversationalService.conversationId": "conversation_id",
             "conversationalService.exchangeId": "exchange_id",
             "conversationalService.messageId": "message_id",
+            "mcpServer.id": "mcp_server_id",
+            "mcpServer.slug": "mcp_server_slug",
         }
 
         attributes_set = set()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -182,6 +182,8 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
             "conversationalService.conversationId": "conv-123",
             "conversationalService.exchangeId": "ex-456",
             "conversationalService.messageId": "msg-789",
+            "mcpServer.id": "server-id-123",
+            "mcpServer.slug": "my-mcp-server",
         }
     }
     config_path = tmp_path / "uipath.json"
@@ -192,6 +194,8 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
     assert ctx.conversation_id == "conv-123"
     assert ctx.exchange_id == "ex-456"
     assert ctx.message_id == "msg-789"
+    assert ctx.mcp_server_id == "server-id-123"
+    assert ctx.mcp_server_slug == "my-mcp-server"
 
 
 def test_from_config_loads_runtime_and_fps_properties(tmp_path: Path) -> None:
@@ -207,6 +211,8 @@ def test_from_config_loads_runtime_and_fps_properties(tmp_path: Path) -> None:
             "conversationalService.conversationId": "conv-abc",
             "conversationalService.exchangeId": "ex-def",
             "conversationalService.messageId": "msg-ghi",
+            "mcpServer.id": "mcp-server-456",
+            "mcpServer.slug": "test-server-slug",
         },
     }
     config_path = tmp_path / "uipath.json"
@@ -226,3 +232,5 @@ def test_from_config_loads_runtime_and_fps_properties(tmp_path: Path) -> None:
     assert ctx.conversation_id == "conv-abc"
     assert ctx.exchange_id == "ex-def"
     assert ctx.message_id == "msg-ghi"
+    assert ctx.mcp_server_id == "mcp-server-456"
+    assert ctx.mcp_server_slug == "test-server-slug"

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
Add fps properties for mcp to the context:
- mcp_server_id
- mcp_server_slug

They are set by agenthub backend when starting a runtime for a coded or command server.

https://github.com/UiPath/AgentHubService/pull/586