### PR TITLE
fix: local debug with resumable runtimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.3.1"
+version = "0.3.2"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -188,20 +188,25 @@ class UiPathDebugRuntime:
                                 final_result
                             )
 
+                            interrupt_id = final_result.trigger.interrupt_id
+                            assert interrupt_id is not None
+
                             resume_data: dict[str, Any] | None = None
                             try:
+                                trigger_data: dict[str, Any] | None = None
                                 if (
                                     final_result.trigger.trigger_type
                                     == UiPathResumeTriggerType.API
                                 ):
-                                    resume_data = (
+                                    trigger_data = (
                                         await self.debug_bridge.wait_for_resume()
                                     )
                                 else:
-                                    resume_data = await self._poll_trigger(
+                                    trigger_data = await self._poll_trigger(
                                         final_result.trigger,
                                         self.delegate.trigger_manager,
                                     )
+                                resume_data = {interrupt_id: trigger_data}
                             except UiPathDebugQuitError:
                                 final_result = UiPathRuntimeResult(
                                     status=UiPathRuntimeStatus.SUCCESSFUL,

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR fixes local debugging with resumable runtimes by ensuring proper handling of trigger data when resuming suspended executions. The main change restructures how resume data is passed between the debug runtime and the resumable runtime to use a consistent `{interrupt_id: trigger_data}` format.

- Refactored trigger fetching and deletion logic in `_restore_resume_input` to handle user-provided input earlier in the flow
- Modified debug runtime to wrap trigger data in the expected `{interrupt_id: trigger_data}` format
- Simplified backward compatibility logic for single trigger access

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.3.2.dev1000590190",

  # Any version from PR
  "uipath-runtime>=0.3.2.dev1000590000,<0.3.2.dev1000600000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```