### PR TITLE
fix: add metadata field to schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.3.3"
+version = "0.3.4"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/schema.py
+++ b/src/uipath/runtime/schema.py
@@ -61,6 +61,9 @@ class UiPathRuntimeSchema(BaseModel):
     graph: UiPathRuntimeGraph | None = Field(
         None, description="Runtime graph structure for debugging"
     )
+    metadata: dict[str, Any] | None = Field(
+        None, description="Additional metadata for the runtime schema"
+    )
 
     model_config = COMMON_MODEL_SCHEMA
 

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

This PR adds an optional metadata field to the `UiPathRuntimeSchema` class to support additional runtime metadata, with a corresponding version bump to `0.3.4`.