### PR TITLE
fix: add factory new runtime kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.3.4"
+version = "0.4.0"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/factory.py
+++ b/src/uipath/runtime/factory.py
@@ -21,7 +21,7 @@ class UiPathRuntimeCreatorProtocol(Protocol):
     """Protocol for creating a UiPath runtime given an entrypoint."""
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str
+        self, entrypoint: str, runtime_id: str, **kwargs
     ) -> UiPathRuntimeProtocol:
         """Create a new runtime instance."""
         ...

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,74 @@
+from typing import Any, AsyncGenerator
+
+import pytest
+
+from uipath.runtime import (
+    UiPathExecuteOptions,
+    UiPathRuntimeEvent,
+    UiPathRuntimeProtocol,
+    UiPathRuntimeResult,
+    UiPathRuntimeSchema,
+    UiPathStreamOptions,
+)
+from uipath.runtime.factory import UiPathRuntimeCreatorProtocol
+
+
+class MockRuntime:
+    """Mock runtime that implements UiPathRuntimeProtocol."""
+
+    def __init__(self, settings: dict[str, Any] | None = None) -> None:
+        self.settings = settings
+
+    async def execute(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
+    ) -> UiPathRuntimeResult:
+        return UiPathRuntimeResult(output={})
+
+    async def stream(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
+    ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
+        yield UiPathRuntimeResult(output={})
+
+    async def get_schema(self) -> UiPathRuntimeSchema:
+        return UiPathRuntimeSchema(
+            filePath="agent.json",
+            type="agent",
+            uniqueId="unique-id",
+            input={},
+            output={},
+        )
+
+    async def dispose(self) -> None:
+        pass
+
+
+class CreatorWithKwargs:
+    """Implementation with kwargs."""
+
+    async def new_runtime(
+        self, entrypoint: str, runtime_id: str, **kwargs
+    ) -> UiPathRuntimeProtocol:
+        return MockRuntime(kwargs.get("settings"))
+
+
+@pytest.mark.asyncio
+async def test_protocol_works_with_kwargs_not_specified():
+    """Test protocol works with implementation that has kwargs."""
+    creator: UiPathRuntimeCreatorProtocol = CreatorWithKwargs()
+    runtime = await creator.new_runtime("main.py", "runtime-123")
+    assert isinstance(runtime, MockRuntime)
+
+
+@pytest.mark.asyncio
+async def test_protocol_works_with_kwargs_specified():
+    """Test protocol works with implementation that has kwargs."""
+    creator: UiPathRuntimeCreatorProtocol = CreatorWithKwargs()
+    runtime = await creator.new_runtime(
+        "main.py", "runtime-123", settings={"timeout": 30, "model": "gpt-4"}
+    )
+    assert isinstance(runtime, MockRuntime)
+    assert runtime.settings == {"timeout": 30, "model": "gpt-4"}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -63,7 +63,7 @@ class MockFunctionsFactory(UiPathRuntimeFactoryProtocol):
         return []
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str
+        self, entrypoint: str, runtime_id: str, **kwargs
     ) -> UiPathRuntimeProtocol:
         return cast(UiPathRuntimeProtocol, MockRuntime(f"functions-{entrypoint}"))
 
@@ -85,7 +85,7 @@ class MockLangGraphFactory(UiPathRuntimeFactoryProtocol):
         return []
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str
+        self, entrypoint: str, runtime_id: str, **kwargs
     ) -> UiPathRuntimeProtocol:
         return cast(UiPathRuntimeProtocol, MockRuntime(f"langgraph-{entrypoint}"))
 
@@ -107,7 +107,7 @@ class MockLlamaIndexFactory(UiPathRuntimeFactoryProtocol):
         return []
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str
+        self, entrypoint: str, runtime_id: str, **kwargs
     ) -> UiPathRuntimeProtocol:
         return cast(UiPathRuntimeProtocol, MockRuntime(f"llamaindex-{entrypoint}"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Description

Allows implementations of `new_runtime()` to accept additional keyword arguments

Bump version to `0.4.0`