### PR TITLE
feat: add UIPATH_LOG_TO_FILE env var for file logging without job context

### DIFF
--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -32,6 +32,7 @@ class UiPathRuntimeContext(BaseModel):
     resume: bool = False
     command: str | None = None
     job_id: str | None = None
+    log_to_file: bool = False
     conversation_id: str | None = Field(
         None, description="Conversation identifier for CAS"
     )
@@ -188,6 +189,7 @@ class UiPathRuntimeContext(BaseModel):
             dir=self.runtime_dir,
             file=self.logs_file,
             job_id=self.job_id,
+            log_to_file=self.log_to_file,
         )
         self.logs_interceptor.setup()
 
@@ -327,6 +329,9 @@ class UiPathRuntimeContext(BaseModel):
 
         # Apply defaults from env
         base.job_id = os.environ.get("UIPATH_JOB_KEY")
+        base.log_to_file = (
+            os.environ.get("UIPATH_LOG_TO_FILE", "").lower() == "true"
+        )
         base.logs_min_level = os.environ.get("LOG_LEVEL", "INFO")
         base.org_id = os.environ.get("UIPATH_ORGANIZATION_ID")
         base.tenant_id = os.environ.get("UIPATH_TENANT_ID")

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -329,9 +329,7 @@ class UiPathRuntimeContext(BaseModel):
 
         # Apply defaults from env
         base.job_id = os.environ.get("UIPATH_JOB_KEY")
-        base.log_to_file = (
-            os.environ.get("UIPATH_LOG_TO_FILE", "").lower() == "true"
-        )
+        base.log_to_file = os.environ.get("UIPATH_LOG_TO_FILE", "").lower() == "true"
         base.logs_min_level = os.environ.get("LOG_LEVEL", "INFO")
         base.org_id = os.environ.get("UIPATH_ORGANIZATION_ID")
         base.tenant_id = os.environ.get("UIPATH_TENANT_ID")

--- a/src/uipath/runtime/logging/_interceptor.py
+++ b/src/uipath/runtime/logging/_interceptor.py
@@ -28,6 +28,7 @@ class UiPathRuntimeLogsInterceptor:
         job_id: str | None = None,
         execution_id: str | None = None,
         log_handler: logging.Handler | None = None,
+        log_to_file: bool = False,
     ):
         """Initialize the log interceptor.
 
@@ -38,6 +39,7 @@ class UiPathRuntimeLogsInterceptor:
             job_id (str, optional): If provided, logs go to file; otherwise, to stdout.
             execution_id (str, optional): Unique identifier for this execution context.
             log_handler (logging.Handler, optional): Custom log handler to use for this execution context.
+            log_to_file (bool): If True, force file logging even without a job_id.
         """
         min_level = min_level or "INFO"
         self.job_id = job_id
@@ -67,8 +69,8 @@ class UiPathRuntimeLogsInterceptor:
         if log_handler:
             self.log_handler = log_handler
         else:
-            # Create either file handler (runtime) or stdout handler (debug)
-            if not job_id:
+            # Create either file handler (runtime/log_to_file) or stdout handler (debug)
+            if not job_id and not log_to_file:
                 # Only wrap if stdout is using a problematic encoding (like cp1252 on Windows)
                 if (
                     hasattr(sys.stdout, "encoding")


### PR DESCRIPTION
## Summary

Adds a `log_to_file` flag to `UiPathRuntimeContext` and `UiPathRuntimeLogsInterceptor` that enables file-based logging (`__uipath/execution.log`) without requiring `UIPATH_JOB_KEY`.

Setting `UIPATH_JOB_KEY` triggers multiple behaviors beyond logging: licensing headers on API calls, output.json writes, state file preservation, and span processor registration. This makes it impossible to test file logging locally without side effects, and in fact doesn't work for evals which are (presently) design time only so the assumption that a deployed job is present will not work.

`UIPATH_LOG_TO_FILE=true` enables only the file logging path — no other behavior changes.

## Test plan

- [x] Verified locally: `UIPATH_LOG_TO_FILE=true uv run uipath eval agent.json default.json` writes to `__uipath/execution.log` with correct formatting
- [x] Existing tests pass (7/7 interceptor tests)
- [x] Without the env var, behavior is unchanged

**Companion PR:** UiPath/uipath-python (pending) — updates `cli_eval.py` to also enable `LiveTrackingSpanProcessor` when `log_to_file` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.10.0.dev1001030389",

  # Any version from PR
  "uipath-runtime>=0.10.0.dev1001030000,<0.10.0.dev1001040000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```