### PR TITLE
ci: fix testcase discovery path in test-uipath workflow

### DIFF
--- a/.github/workflows/test-uipath.yml
+++ b/.github/workflows/test-uipath.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Discover testcases
         id: discover
-        working-directory: uipath-python
+        working-directory: uipath-python/packages/uipath
         run: |
           # Find all testcase folders (excluding common folders like README, etc.)
           testcase_dirs=$(find testcases -maxdepth 1 -type d -name "*-*" | sed 's|testcases/||' | sort)
@@ -175,7 +175,7 @@ jobs:
           BASE_URL:       ${{ matrix.environment == 'alpha' && secrets.ALPHA_BASE_URL || matrix.environment == 'staging' && secrets.STAGING_BASE_URL || matrix.environment == 'cloud' && secrets.CLOUD_BASE_URL }}
           USE_AZURE_CHAT: ${{ matrix.use_azure_chat }}
           UV_PYTHON: "3.12"
-        working-directory: uipath-python/testcases/${{ matrix.testcase }}
+        working-directory: uipath-python/packages/uipath/testcases/${{ matrix.testcase }}
         run: |
           echo "Running testcase: ${{ matrix.testcase }}"
           echo "Environment: ${{ matrix.environment }}"


### PR DESCRIPTION
## Summary
- point testcase discovery and per-testcase working directory at \`uipath-python/packages/uipath/testcases/\` instead of the non-existent repo-root \`testcases/\`

## Why

the integration test job was failing before running anything because \`find testcases\` at the \`uipath-python\` repo root returned nothing, the matrix fanned out an empty-string testcase entry, and the container tried to chdir into a path that does not exist. the testcases live under \`packages/uipath/testcases/\` after the mono-repo refactor