### PR TITLE
chore: narrow voice_mode to Literal["session"]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.10.3"
+version = "0.10.4"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -37,7 +37,7 @@ class UiPathRuntimeContext(BaseModel):
     )
     exchange_id: str | None = Field(None, description="Exchange identifier for CAS")
     message_id: str | None = Field(None, description="Message identifier for CAS")
-    voice_mode: Literal["config", "toolCall"] | None = Field(
+    voice_mode: Literal["session"] | None = Field(
         None, description="Voice job type for CAS"
     )
     mcp_server_id: str | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Summary
- deprecated "config", "toolCall" and now we only support "session"
- all voice agents are already on "session" since last sprint payload