### PR TITLE
chore: enforce 2-day minimum age for non-uipath packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,12 @@ exclude_lines = [
   "@(abc\\.)?abstractmethod",
 ]
 
+[tool.uv]
+exclude-newer = "2 days"
+
+[tool.uv.exclude-newer-package]
+uipath-core = false
+
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+uipath-core = false
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
Prudent against supply chain attacks.