### PR TITLE
feat: export resolved conversation_id to UIPATH_CONVERSATION_ID env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.10.4"
+version = "0.10.5"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -337,6 +337,11 @@ class UiPathRuntimeContext(BaseModel):
         for k, v in kwargs.items():
             setattr(base, k, v)
 
+        # Export resolved conversation ID (from fpsProperties). Used for specific tools run by 
+        # conversational-agents to have the conversation ID passed in.
+        if base.conversation_id:
+            os.environ["UIPATH_CONVERSATION_ID"] = base.conversation_id
+
         return base
 
     @classmethod

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -337,7 +337,7 @@ class UiPathRuntimeContext(BaseModel):
         for k, v in kwargs.items():
             setattr(base, k, v)
 
-        # Export resolved conversation ID (from fpsProperties). Used for specific tools run by 
+        # Export resolved conversation ID (from fpsProperties). Used for specific tools run by
         # conversational-agents to have the conversation ID passed in.
         if base.conversation_id:
             os.environ["UIPATH_CONVERSATION_ID"] = base.conversation_id

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -241,6 +241,26 @@ def test_from_config_loads_runtime_and_fps_properties(tmp_path: Path) -> None:
     assert ctx.mcp_server_slug == "test-server-slug"
 
 
+def test_with_defaults_exports_conversation_id_to_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolved conversation_id should be exported to UIPATH_CONVERSATION_ID."""
+    cfg = {
+        "fpsProperties": {
+            "conversationalService.conversationId": "conv-from-config",
+        }
+    }
+    config_path = tmp_path / "uipath.json"
+    config_path.write_text(json.dumps(cfg))
+    monkeypatch.delenv("UIPATH_CONVERSATION_ID", raising=False)
+
+    UiPathRuntimeContext.with_defaults(config_path=str(config_path))
+
+    import os
+
+    assert os.environ.get("UIPATH_CONVERSATION_ID") == "conv-from-config"
+
+
 def test_result_file_written_on_faulted_trigger_error(tmp_path: Path) -> None:
     runtime_dir = tmp_path / "runtime"
     ctx = UiPathRuntimeContext(

--- a/uv.lock
+++ b/uv.lock
@@ -1012,7 +1012,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## Summary

At the end of `UiPathRuntimeContext.with_defaults()`, export the resolved `conversation_id` which comes from `fpsProperties.conversationalService.conversationId`  to `os.environ["UIPATH_CONVERSATION_ID"]` so downstream tool implementations can read it. This is the simplest method as it does not need the runtime context plumbed through every call site.

The conversation id is resolved from `fpsProperties.conversationalService.conversationId` in `uipath.json` (and any override applied via kwargs), then exported once. Only set when present — no-op when missing.

### Motivation

A follow-up [change](https://github.com/UiPath/uipath-langchain-python/pull/878) in `uipath-langchain-python` auto-injects the conversation id into Orchestrator/Maestro tool calls whose input schemas declare a `UIPATH_RESERVED_CONVERSATIONID` argument. Those tools need a low-friction way to access the conversation id at execution time.

## Test plan

- [x] `tests/test_context.py::test_with_defaults_exports_conversation_id_to_env` — verifies a config-supplied conversation id ends up in `os.environ`
- [x] Existing `with_defaults()` / `from_config()` tests still pass