### PR TITLE
feat: map conversationalService.conversationalUserId to runtime context [JAR-9965]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.11.0"
+version = "0.11.1"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -37,6 +37,9 @@ class UiPathRuntimeContext(BaseModel):
     )
     exchange_id: str | None = Field(None, description="Exchange identifier for CAS")
     message_id: str | None = Field(None, description="Message identifier for CAS")
+    synthetic_user_id: str | None = Field(
+        None, description="Conversation owner id (synthetic user) for CAS"
+    )
     voice_mode: Literal["session"] | None = Field(
         None, description="Voice job type for CAS"
     )
@@ -364,6 +367,7 @@ class UiPathRuntimeContext(BaseModel):
             "conversationalService.conversationId": "conversation_id",
             "conversationalService.exchangeId": "exchange_id",
             "conversationalService.messageId": "message_id",
+            "conversationalService.syntheticUserId": "synthetic_user_id",
             "mcpServer.id": "mcp_server_id",
             "mcpServer.slug": "mcp_server_slug",
             "voice.mode": "voice_mode",

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -37,8 +37,9 @@ class UiPathRuntimeContext(BaseModel):
     )
     exchange_id: str | None = Field(None, description="Exchange identifier for CAS")
     message_id: str | None = Field(None, description="Message identifier for CAS")
-    synthetic_user_id: str | None = Field(
-        None, description="Conversation owner id (synthetic user) for CAS"
+    conversational_user_id: str | None = Field(
+        None,
+        description="Conversation owner id for CAS (a real cloud user id or a synthetic user id)",
     )
     voice_mode: Literal["session"] | None = Field(
         None, description="Voice job type for CAS"
@@ -367,7 +368,7 @@ class UiPathRuntimeContext(BaseModel):
             "conversationalService.conversationId": "conversation_id",
             "conversationalService.exchangeId": "exchange_id",
             "conversationalService.messageId": "message_id",
-            "conversationalService.syntheticUserId": "synthetic_user_id",
+            "conversationalService.conversationalUserId": "conversational_user_id",
             "mcpServer.id": "mcp_server_id",
             "mcpServer.slug": "mcp_server_slug",
             "voice.mode": "voice_mode",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -183,6 +183,7 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
             "conversationalService.conversationId": "conv-123",
             "conversationalService.exchangeId": "ex-456",
             "conversationalService.messageId": "msg-789",
+            "conversationalService.syntheticUserId": "owner-guid",
             "mcpServer.id": "server-id-123",
             "mcpServer.slug": "my-mcp-server",
         }
@@ -195,6 +196,7 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
     assert ctx.conversation_id == "conv-123"
     assert ctx.exchange_id == "ex-456"
     assert ctx.message_id == "msg-789"
+    assert ctx.synthetic_user_id == "owner-guid"
     assert ctx.mcp_server_id == "server-id-123"
     assert ctx.mcp_server_slug == "my-mcp-server"
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -183,7 +183,7 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
             "conversationalService.conversationId": "conv-123",
             "conversationalService.exchangeId": "ex-456",
             "conversationalService.messageId": "msg-789",
-            "conversationalService.syntheticUserId": "owner-guid",
+            "conversationalService.conversationalUserId": "owner-guid",
             "mcpServer.id": "server-id-123",
             "mcpServer.slug": "my-mcp-server",
         }
@@ -196,7 +196,7 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
     assert ctx.conversation_id == "conv-123"
     assert ctx.exchange_id == "ex-456"
     assert ctx.message_id == "msg-789"
-    assert ctx.synthetic_user_id == "owner-guid"
+    assert ctx.conversational_user_id == "owner-guid"
     assert ctx.mcp_server_id == "server-id-123"
     assert ctx.mcp_server_slug == "my-mcp-server"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-05-27T14:28:49.412753Z"
+exclude-newer = "2026-06-16T20:40:40.185404Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -1012,7 +1012,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "uipath-core" },


### PR DESCRIPTION
## TL;DR
Map `conversationalService.conversationalUserId` from FpsProperties onto a new `conversational_user_id` field on `UiPathRuntimeContext`, so the conversational bridge can present the conversation owner id to CAS on the WebSocket handshake.

## Solution
- `runtime/context.py`: add `conversational_user_id: str | None` to `UiPathRuntimeContext` and a `fps_mappings` entry `"conversationalService.conversationalUserId" -> "conversational_user_id"`. The value may be a real cloud user id or a synthetic user id.
- Test in `tests/test_context.py` (asserts the fps key maps onto the field).

## Consumed by
`uipath` bridge (sends it as the `X-UiPath-Internal-ConversationalUserId` handshake header) → AgentInterfaces CAS (validates against `conversation.user_id` to authorize Unified Runtime Robot connections for RunAsMe=false conversations).
