### PR TITLE
chore(voice): align runtime context with session voice mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.11.8"
+version = "0.11.9"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -55,7 +55,7 @@ class UiPathRuntimeContext(BaseModel):
         None,
         description="Conversation owner id for CAS (a real cloud user id or a synthetic user id)",
     )
-    voice_mode: Literal["session"] | None = Field(
+    voice_mode: Literal["session", "maestro_flow"] | None = Field(
         None, description="Voice job type for CAS"
     )
     mcp_server_id: str | None = None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from uipath.core.errors import ErrorCategory, UiPathFaultedTriggerError
 
 from uipath.runtime.context import UiPathRuntimeContext
@@ -371,3 +372,29 @@ def test_explicit_execution_source_not_overwritten() -> None:
     ctx = UiPathRuntimeContext(command="run", execution_source="custom")
 
     assert ctx.execution_source == "custom"
+
+
+@pytest.mark.parametrize("voice_mode", ["session", "maestro_flow"])
+def test_constructor_accepts_supported_voice_modes(voice_mode: str) -> None:
+    ctx = UiPathRuntimeContext(voice_mode=voice_mode)
+
+    assert ctx.voice_mode == voice_mode
+
+
+@pytest.mark.parametrize("voice_mode", ["session", "maestro_flow"])
+def test_from_config_accepts_supported_voice_modes(
+    voice_mode: str, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "uipath.json"
+    config_path.write_text(
+        json.dumps({"fpsProperties": {"voice.mode": voice_mode}})
+    )
+
+    ctx = UiPathRuntimeContext.from_config(str(config_path))
+
+    assert ctx.voice_mode == voice_mode
+
+
+def test_constructor_rejects_unknown_voice_mode() -> None:
+    with pytest.raises(ValidationError):
+        UiPathRuntimeContext(voice_mode="chat")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -393,6 +393,12 @@ def test_explicit_execution_source_not_overwritten() -> None:
     assert ctx.execution_source == "custom"
 
 
+def test_constructor_accepts_maestro_flow_voice_mode() -> None:
+    ctx = UiPathRuntimeContext(voice_mode="maestro_flow")
+
+    assert ctx.voice_mode == "maestro_flow"
+
+
 def test_from_config_accepts_maestro_flow_voice_mode(tmp_path: Path) -> None:
     config_path = tmp_path / "uipath.json"
     config_path.write_text(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
 from uipath.core.errors import ErrorCategory, UiPathFaultedTriggerError
 
 from uipath.runtime.context import UiPathRuntimeContext
@@ -374,27 +373,12 @@ def test_explicit_execution_source_not_overwritten() -> None:
     assert ctx.execution_source == "custom"
 
 
-@pytest.mark.parametrize("voice_mode", ["session", "maestro_flow"])
-def test_constructor_accepts_supported_voice_modes(voice_mode: str) -> None:
-    ctx = UiPathRuntimeContext(voice_mode=voice_mode)
-
-    assert ctx.voice_mode == voice_mode
-
-
-@pytest.mark.parametrize("voice_mode", ["session", "maestro_flow"])
-def test_from_config_accepts_supported_voice_modes(
-    voice_mode: str, tmp_path: Path
-) -> None:
+def test_from_config_accepts_maestro_flow_voice_mode(tmp_path: Path) -> None:
     config_path = tmp_path / "uipath.json"
     config_path.write_text(
-        json.dumps({"fpsProperties": {"voice.mode": voice_mode}})
+        json.dumps({"fpsProperties": {"voice.mode": "maestro_flow"}})
     )
 
     ctx = UiPathRuntimeContext.from_config(str(config_path))
 
-    assert ctx.voice_mode == voice_mode
-
-
-def test_constructor_rejects_unknown_voice_mode() -> None:
-    with pytest.raises(ValidationError):
-        UiPathRuntimeContext(voice_mode="chat")
+    assert ctx.voice_mode == "maestro_flow"

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.8"
+version = "0.11.9"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
Draft support for AgentInterfaces flow-part-2 voice session runtime plumbing. Not required for AgentInterfaces #1013. This updates the runtime context voice_mode contract toward session mode; the local editable dependency changes should be reviewed before this is made ready.