### PR TITLE
Treat timer triggers as external resume triggers

### DIFF
--- a/src/uipath/runtime/resumable/protocols.py
+++ b/src/uipath/runtime/resumable/protocols.py
@@ -68,6 +68,24 @@ class UiPathResumeTriggerCreatorProtocol(Protocol):
         """
         ...
 
+    async def create_triggers(self, suspend_value: Any) -> list[UiPathResumeTrigger]:
+        """Create resume triggers from a suspend value.
+
+        Most suspend values produce one trigger. Values with alternative resume
+        conditions, such as operation timeouts, may produce multiple triggers for
+        the same interrupt.
+
+        Args:
+            suspend_value: The value that caused the suspension.
+
+        Returns:
+            UiPathResumeTrigger objects ready to be persisted.
+
+        Raises:
+            UiPathRuntimeError: If trigger creation fails
+        """
+        ...
+
 
 class UiPathResumeTriggerReaderProtocol(Protocol):
     """Protocol for reading resume triggers and converting them to runtime input."""

--- a/src/uipath/runtime/resumable/runtime.py
+++ b/src/uipath/runtime/resumable/runtime.py
@@ -147,8 +147,9 @@ class UiPathResumableRuntime:
     async def _get_fired_triggers(self) -> dict[str, Any] | None:
         """Check stored triggers for any that have already fired.
 
-        Skips async-external triggers (API, Inbox) whose payloads only arrive
-        asynchronously and cannot be polled at suspend time.
+        Skips external triggers (API, Inbox, Timer) whose payloads only arrive
+        asynchronously or through Orchestrator resume and cannot be polled at
+        suspend time.
 
         Returns:
             A resume map of {interrupt_id: resume_data} for fired triggers, or None.
@@ -161,7 +162,11 @@ class UiPathResumableRuntime:
             t
             for t in triggers
             if t.trigger_type
-            not in (UiPathResumeTriggerType.API, UiPathResumeTriggerType.INBOX)
+            not in (
+                UiPathResumeTriggerType.API,
+                UiPathResumeTriggerType.INBOX,
+                UiPathResumeTriggerType.TIMER,
+            )
         ]
         return await self._build_resume_map(pollable_triggers)
 

--- a/src/uipath/runtime/resumable/runtime.py
+++ b/src/uipath/runtime/resumable/runtime.py
@@ -225,11 +225,14 @@ class UiPathResumableRuntime:
         """
         resume_map: dict[str, Any] = {}
         for trigger in triggers:
+            assert trigger.interrupt_id is not None, (
+                "Trigger interrupt_id cannot be None"
+            )
+            if trigger.interrupt_id in resume_map:
+                continue
+
             try:
                 data = await self.trigger_manager.read_trigger(trigger)
-                assert trigger.interrupt_id is not None, (
-                    "Trigger interrupt_id cannot be None"
-                )
                 resume_map[trigger.interrupt_id] = data
                 await self.storage.delete_trigger(self.runtime_id, trigger)
             except UiPathPendingTriggerError:
@@ -273,11 +276,12 @@ class UiPathResumableRuntime:
 
         # Create triggers only for new interrupts
         for interrupt_id in new_ids:
-            trigger = await self.trigger_manager.create_trigger(
+            triggers = await self.trigger_manager.create_triggers(
                 current_interrupts[interrupt_id]
             )
-            trigger.interrupt_id = interrupt_id
-            suspended_result.triggers.append(trigger)
+            for trigger in triggers:
+                trigger.interrupt_id = interrupt_id
+                suspended_result.triggers.append(trigger)
 
         if suspended_result.triggers:
             await self.storage.save_triggers(self.runtime_id, suspended_result.triggers)

--- a/tests/test_resumable.py
+++ b/tests/test_resumable.py
@@ -134,6 +134,11 @@ def make_trigger_manager_mock() -> UiPathResumeTriggerProtocol:
         raise UiPathPendingTriggerError(ErrorCategory.USER, "Trigger not fired yet")
 
     manager.create_trigger = AsyncMock(side_effect=create_trigger_impl)
+
+    async def create_triggers_impl(data: dict[str, Any]) -> list[UiPathResumeTrigger]:
+        return [await manager.create_trigger(data)]
+
+    manager.create_triggers = AsyncMock(side_effect=create_triggers_impl)
     manager.read_trigger = AsyncMock(side_effect=read_trigger_default)
 
     return cast(UiPathResumeTriggerProtocol, manager)


### PR DESCRIPTION
Timer resume triggers are completed by Orchestrator after the job suspends. The resumable runtime should persist them and let Orchestrator handle the wake-up instead of polling them immediately in the same process, which can self-resume before the job ever reaches Suspended.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.11.4.dev1001360546",

  # Any version from PR
  "uipath-runtime>=0.11.4.dev1001360000,<0.11.4.dev1001370000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```