### PR TITLE
feat: support multiple resume triggers per interrupt

### DIFF
--- a/.github/scripts/force-runtime-override.py
+++ b/.github/scripts/force-runtime-override.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Force cross-repo uv resolves to use the runtime wheel under test."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def _quoted(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _add_override(pyproject_path: Path, override: str) -> None:
+    text = pyproject_path.read_text()
+    quoted_override = _quoted(override)
+
+    if override in text:
+        return
+
+    tool_uv_match = re.search(
+        r"(?ms)^\[tool\.uv\]\n(?P<body>.*?)(?=^\[|\Z)",
+        text,
+    )
+    if not tool_uv_match:
+        text = (
+            text.rstrip()
+            + f"\n\n[tool.uv]\noverride-dependencies = [{quoted_override}]\n"
+        )
+        pyproject_path.write_text(text)
+        return
+
+    body = tool_uv_match.group("body")
+    override_match = re.search(
+        r"(?ms)^override-dependencies\s*=\s*\[(?P<items>.*?)\]\s*",
+        body,
+    )
+    if override_match:
+        items = override_match.group("items").strip()
+        if quoted_override in items:
+            return
+
+        if items:
+            replacement = f"override-dependencies = [{items}, {quoted_override}]\n"
+        else:
+            replacement = f"override-dependencies = [{quoted_override}]\n"
+
+        body = (
+            body[: override_match.start()] + replacement + body[override_match.end() :]
+        )
+    else:
+        body = f"override-dependencies = [{quoted_override}]\n" + body
+
+    text = (
+        text[: tool_uv_match.start("body")] + body + text[tool_uv_match.end("body") :]
+    )
+    pyproject_path.write_text(text)
+
+
+def main() -> None:
+    """Add a local runtime wheel override to a pyproject and print the wheel path."""
+    if len(sys.argv) != 3:
+        print(
+            "usage: force-runtime-override.py <pyproject.toml> <runtime-wheel-dir>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    pyproject_path = Path(sys.argv[1])
+    wheel_dir = Path(sys.argv[2])
+    wheels = sorted(wheel_dir.glob("uipath_runtime-*.whl"))
+    if not wheels:
+        print(f"no uipath-runtime wheel found in {wheel_dir}", file=sys.stderr)
+        raise SystemExit(1)
+    if len(wheels) > 1:
+        wheel_names = ", ".join(str(wheel) for wheel in wheels)
+        print(
+            f"expected one uipath-runtime wheel in {wheel_dir}, found: {wheel_names}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    wheel = wheels[0].resolve()
+
+    _add_override(pyproject_path, f"uipath-runtime @ {wheel.as_uri()}")
+    print(wheel)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Update uipath-runtime version
         shell: bash
         working-directory: uipath-langchain-python
-        run: uv add ../uipath-runtime-python/dist/*.whl --dev
+        run: |
+          runtime_wheel="$(python ../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../uipath-runtime-python/dist)"
+          uv add "$runtime_wheel" --dev
 
       - name: Run uipath-langchain tests
         working-directory: uipath-langchain-python
@@ -89,7 +91,9 @@ jobs:
       - name: Update uipath-runtime version
         shell: bash
         working-directory: uipath-langchain-python
-        run: uv add ../uipath-runtime-python/dist/*.whl --dev
+        run: |
+          runtime_wheel="$(python ../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../uipath-runtime-python/dist)"
+          uv add "$runtime_wheel" --dev
 
       - name: Run typecheck
         working-directory: uipath-langchain-python
@@ -163,7 +167,9 @@ jobs:
       - name: Update uipath-runtime version
         shell: bash
         working-directory: uipath-langchain-python
-        run: uv add ../uipath-runtime-python/dist/*.whl --dev
+        run: |
+          runtime_wheel="$(python ../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../uipath-runtime-python/dist)"
+          uv add "$runtime_wheel" --dev
 
       - name: Install dependencies
         working-directory: uipath-langchain-python
@@ -182,8 +188,8 @@ jobs:
           echo "Environment: ${{ matrix.environment }}"
           echo "LLM: ${{ matrix.use_azure_chat && 'UiPathAzureChatOpenAI' || 'UiPathChat' }}"
           echo "USE_AZURE_CHAT: ${{ matrix.use_azure_chat }}"
+          python ../../../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../../../uipath-runtime-python/dist
 
           # Execute the testcase run script directly
           bash run.sh
           bash ../common/validate_output.sh
-

--- a/.github/workflows/test-uipath.yml
+++ b/.github/workflows/test-uipath.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Update uipath-runtime version
         shell: bash
         working-directory: uipath-python/packages/uipath
-        run: uv add ../../../uipath-runtime-python/dist/*.whl --dev
+        run: |
+          runtime_wheel="$(python ../../../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../../../uipath-runtime-python/dist)"
+          uv add "$runtime_wheel" --dev
 
       - name: Run uipath tests
         working-directory: uipath-python/packages/uipath
@@ -89,7 +91,9 @@ jobs:
       - name: Update uipath-runtime version
         shell: bash
         working-directory: uipath-python/packages/uipath
-        run: uv add ../../../uipath-runtime-python/dist/*.whl --dev
+        run: |
+          runtime_wheel="$(python ../../../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../../../uipath-runtime-python/dist)"
+          uv add "$runtime_wheel" --dev
 
       - name: Run typecheck
         working-directory: uipath-python/packages/uipath
@@ -162,7 +166,9 @@ jobs:
       - name: Update uipath-runtime version
         shell: bash
         working-directory: uipath-python/packages/uipath
-        run: uv add ../../../uipath-runtime-python/dist/*.whl --dev
+        run: |
+          runtime_wheel="$(python ../../../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../../../uipath-runtime-python/dist)"
+          uv add "$runtime_wheel" --dev
 
       - name: Install dependencies
         working-directory: uipath-python/packages/uipath
@@ -179,8 +185,8 @@ jobs:
         run: |
           echo "Running testcase: ${{ matrix.testcase }}"
           echo "Environment: ${{ matrix.environment }}"
+          python ../../../../../uipath-runtime-python/.github/scripts/force-runtime-override.py pyproject.toml ../../../../../uipath-runtime-python/dist
 
           # Execute the testcase run script directly
           bash run.sh
           bash ../common/validate_output.sh
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.11.8"
+version = "0.12.0"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/resumable/protocols.py
+++ b/src/uipath/runtime/resumable/protocols.py
@@ -4,6 +4,8 @@ from typing import Any, Protocol
 
 from uipath.core.triggers import UiPathResumeTrigger
 
+from uipath.runtime.errors import UiPathRuntimeError
+from uipath.runtime.errors.codes import UiPathErrorCode
 from uipath.runtime.storage import UiPathRuntimeStorageProtocol
 
 
@@ -34,6 +36,20 @@ class UiPathResumableStorageProtocol(UiPathRuntimeStorageProtocol, Protocol):
         """
         ...
 
+    async def delete_triggers(
+        self, runtime_id: str, triggers: list[UiPathResumeTrigger]
+    ) -> None:
+        """Delete resume triggers from storage.
+
+        Args:
+            runtime_id: The runtime ID
+            triggers: The resume triggers to delete
+
+        Raises:
+            Exception: If deletion operation fails
+        """
+        ...
+
     async def delete_trigger(
         self, runtime_id: str, trigger: UiPathResumeTrigger
     ) -> None:
@@ -46,7 +62,8 @@ class UiPathResumableStorageProtocol(UiPathRuntimeStorageProtocol, Protocol):
         Raises:
             Exception: If deletion operation fails
         """
-        ...
+        # TODO: Remove this compatibility alias in the next minor version.
+        await self.delete_triggers(runtime_id, [trigger])
 
 
 class UiPathResumeTriggerCreatorProtocol(Protocol):
@@ -62,6 +79,34 @@ class UiPathResumeTriggerCreatorProtocol(Protocol):
 
         Returns:
             UiPathResumeTrigger ready to be persisted
+
+        Raises:
+            UiPathRuntimeError: If trigger creation fails
+        """
+        # TODO: Remove this compatibility alias in the next minor version.
+        triggers = await self.create_triggers(suspend_value)
+        if len(triggers) != 1:
+            raise UiPathRuntimeError(
+                code=UiPathErrorCode.CREATE_RESUME_TRIGGER_ERROR,
+                title="Unexpected resume trigger count",
+                detail=(
+                    "create_trigger() cannot return multiple resume triggers. "
+                    "Use create_triggers() instead."
+                ),
+            )
+        return triggers[0]
+
+    async def create_triggers(self, suspend_value: Any) -> list[UiPathResumeTrigger]:
+        """Create resume triggers from a suspend value.
+
+        Most suspend values produce one trigger. Composite values may produce
+        multiple sibling triggers for the same interrupt.
+
+        Args:
+            suspend_value: The value that caused the suspension.
+
+        Returns:
+            UiPathResumeTrigger objects ready to be persisted.
 
         Raises:
             UiPathRuntimeError: If trigger creation fails

--- a/src/uipath/runtime/resumable/runtime.py
+++ b/src/uipath/runtime/resumable/runtime.py
@@ -1,10 +1,16 @@
 """Resumable runtime protocol and implementation."""
 
 import logging
+from collections import Counter
+from enum import Enum
 from typing import Any, AsyncGenerator
 
 from uipath.core.errors import UiPathPendingTriggerError
-from uipath.core.triggers import UiPathResumeTrigger, UiPathResumeTriggerType
+from uipath.core.triggers import (
+    UIPATH_METADATA_KEY,
+    UiPathResumeTrigger,
+    UiPathResumeTriggerType,
+)
 
 from uipath.runtime.base import (
     UiPathExecuteOptions,
@@ -168,7 +174,7 @@ class UiPathResumableRuntime:
                 UiPathResumeTriggerType.TIMER,
             )
         ]
-        return await self._build_resume_map(pollable_triggers)
+        return await self._build_resume_map(pollable_triggers, all_triggers=triggers)
 
     async def _restore_resume_input(
         self,
@@ -190,15 +196,17 @@ class UiPathResumableRuntime:
             if triggers:
                 if len(triggers) == 1:
                     # Single trigger - just delete it
-                    await self.storage.delete_trigger(self.runtime_id, triggers[0])
+                    await self.storage.delete_triggers(self.runtime_id, triggers)
                 else:
                     # Multiple triggers - match by interrupt_id
-                    found = False
-                    for trigger in triggers:
-                        if trigger.interrupt_id in input:
-                            await self.storage.delete_trigger(self.runtime_id, trigger)
-                            found = True
-                    if not found:
+                    matched_triggers = [
+                        trigger for trigger in triggers if trigger.interrupt_id in input
+                    ]
+                    if matched_triggers:
+                        await self.storage.delete_triggers(
+                            self.runtime_id, matched_triggers
+                        )
+                    else:
                         logger.warning(
                             f"Multiple triggers detected but none match the provided input. "
                             f"Please specify which trigger to resume by {{interrupt_id: value}}. "
@@ -213,30 +221,74 @@ class UiPathResumableRuntime:
 
     async def _build_resume_map(
         self,
-        triggers: list[UiPathResumeTrigger],
+        pollable_triggers: list[UiPathResumeTrigger],
+        all_triggers: list[UiPathResumeTrigger] | None = None,
     ) -> dict[str, Any]:
         """Build resume map from triggers: {interrupt_id: resume_data}.
 
         Args:
-            triggers: List of triggers to read and map
+            pollable_triggers: List of triggers to read and map.
+            all_triggers: Optional full trigger set for the same suspension.
+                When provided, it is used to detect and delete sibling triggers
+                that are not pollable.
 
         Returns:
             A dict mapping interrupt_id to the trigger's resume data.
         """
         resume_map: dict[str, Any] = {}
-        for trigger in triggers:
+        triggers_to_match = (
+            all_triggers if all_triggers is not None else pollable_triggers
+        )
+        trigger_count_by_interrupt_id = Counter(
+            trigger.interrupt_id for trigger in triggers_to_match
+        )
+        for trigger in pollable_triggers:
+            assert trigger.interrupt_id is not None, (
+                "Trigger interrupt_id cannot be None"
+            )
+            # one fired sibling is enough to resume an interrupt; skip the rest.
+            if trigger.interrupt_id in resume_map:
+                continue
+
             try:
                 data = await self.trigger_manager.read_trigger(trigger)
-                assert trigger.interrupt_id is not None, (
-                    "Trigger interrupt_id cannot be None"
-                )
+                if trigger_count_by_interrupt_id[trigger.interrupt_id] > 1:
+                    data = self._with_trigger_metadata(trigger, data)
                 resume_map[trigger.interrupt_id] = data
-                await self.storage.delete_trigger(self.runtime_id, trigger)
+                sibling_triggers = [
+                    sibling
+                    for sibling in triggers_to_match
+                    if sibling.interrupt_id == trigger.interrupt_id
+                ]
+                await self.storage.delete_triggers(self.runtime_id, sibling_triggers)
             except UiPathPendingTriggerError:
                 # Trigger still pending, skip it
                 pass
 
         return resume_map
+
+    def _with_trigger_metadata(
+        self, trigger: UiPathResumeTrigger, data: Any
+    ) -> dict[str, Any]:
+        def normalize_enum_values(value: Any) -> Any:
+            if isinstance(value, Enum):
+                return value.value
+
+            return value
+
+        metadata = {
+            "triggerType": normalize_enum_values(trigger.trigger_type),
+            "triggerName": normalize_enum_values(trigger.trigger_name),
+        }
+
+        if isinstance(data, dict):
+            existing_metadata = data.get(UIPATH_METADATA_KEY)
+            if isinstance(existing_metadata, dict):
+                metadata = {**existing_metadata, **metadata}
+
+            return {**data, UIPATH_METADATA_KEY: metadata}
+
+        return {UIPATH_METADATA_KEY: metadata, "value": data}
 
     async def _handle_suspension(
         self, result: UiPathRuntimeResult
@@ -273,11 +325,12 @@ class UiPathResumableRuntime:
 
         # Create triggers only for new interrupts
         for interrupt_id in new_ids:
-            trigger = await self.trigger_manager.create_trigger(
+            triggers = await self.trigger_manager.create_triggers(
                 current_interrupts[interrupt_id]
             )
-            trigger.interrupt_id = interrupt_id
-            suspended_result.triggers.append(trigger)
+            for trigger in triggers:
+                trigger.interrupt_id = interrupt_id
+                suspended_result.triggers.append(trigger)
 
         if suspended_result.triggers:
             await self.storage.save_triggers(self.runtime_id, suspended_result.triggers)

--- a/tests/test_resumable.py
+++ b/tests/test_resumable.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from uipath.core.errors import ErrorCategory, UiPathPendingTriggerError
-from uipath.core.triggers import UiPathResumeTrigger, UiPathResumeTriggerType
+from uipath.core.triggers import (
+    UiPathResumeTrigger,
+    UiPathResumeTriggerName,
+    UiPathResumeTriggerType,
+)
 
 from uipath.runtime import (
     UiPathExecuteOptions,
@@ -15,15 +19,17 @@ from uipath.runtime import (
     UiPathRuntimeStatus,
     UiPathStreamOptions,
 )
+from uipath.runtime.errors import UiPathRuntimeError
 from uipath.runtime.events import UiPathRuntimeEvent
 from uipath.runtime.resumable.protocols import (
+    UiPathResumableStorageProtocol,
     UiPathResumeTriggerProtocol,
 )
 from uipath.runtime.resumable.runtime import UiPathResumableRuntime
 from uipath.runtime.schema import UiPathRuntimeSchema
 
 
-class MultiTriggerMockRuntime:
+class SiblingTriggerMockRuntime:
     """Mock runtime that simulates parallel branching with multiple interrupts."""
 
     def __init__(self) -> None:
@@ -89,6 +95,56 @@ class MultiTriggerMockRuntime:
         raise NotImplementedError()
 
 
+class MultiTriggerMockRuntime:
+    """Mock runtime that suspends on a multi-trigger interrupt, then suspends again."""
+
+    def __init__(self) -> None:
+        self.execution_count = 0
+
+    async def dispose(self) -> None:
+        pass
+
+    async def execute(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
+    ) -> UiPathRuntimeResult:
+        self.execution_count += 1
+        is_resume = options and options.resume
+
+        if self.execution_count == 1:
+            return UiPathRuntimeResult(
+                status=UiPathRuntimeStatus.SUSPENDED,
+                output={"child-1": {"process": "first-child"}},
+            )
+
+        assert is_resume
+        assert input == {
+            "child-1": {
+                "completed": True,
+                "__uipath": {
+                    "triggerType": UiPathResumeTriggerType.JOB.value,
+                    "triggerName": "Unknown",
+                },
+            }
+        }
+        return UiPathRuntimeResult(
+            status=UiPathRuntimeStatus.SUSPENDED,
+            output={"child-2": {"process": "second-child"}},
+        )
+
+    async def stream(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
+    ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
+        result = await self.execute(input, options)
+        yield result
+
+    async def get_schema(self) -> UiPathRuntimeSchema:
+        raise NotImplementedError()
+
+
 class StatefulStorageMock:
     """Stateful storage mock that tracks triggers."""
 
@@ -106,8 +162,14 @@ class StatefulStorageMock:
     async def delete_trigger(
         self, runtime_id: str, trigger: UiPathResumeTrigger
     ) -> None:
+        await self.delete_triggers(runtime_id, [trigger])
+
+    async def delete_triggers(
+        self, runtime_id: str, triggers: list[UiPathResumeTrigger]
+    ) -> None:
+        interrupt_ids = {trigger.interrupt_id for trigger in triggers}
         self.triggers = [
-            t for t in self.triggers if t.interrupt_id != trigger.interrupt_id
+            t for t in self.triggers if t.interrupt_id not in interrupt_ids
         ]
 
     async def set_value(
@@ -116,6 +178,56 @@ class StatefulStorageMock:
         pass
 
     async def get_value(self, runtime_id: str, namespace: str, key: str) -> Any:
+        return None
+
+
+class DeprecatedDeleteAliasStorage(UiPathResumableStorageProtocol):
+    """Storage that relies on the protocol's deprecated singular delete alias."""
+
+    def __init__(self) -> None:
+        self.deleted_triggers: list[UiPathResumeTrigger] = []
+
+    async def get_triggers(self, runtime_id: str) -> list[UiPathResumeTrigger]:
+        return []
+
+    async def save_triggers(
+        self, runtime_id: str, triggers: list[UiPathResumeTrigger]
+    ) -> None:
+        pass
+
+    async def delete_triggers(
+        self, runtime_id: str, triggers: list[UiPathResumeTrigger]
+    ) -> None:
+        self.deleted_triggers.extend(triggers)
+
+    async def set_value(
+        self, runtime_id: str, namespace: str, key: str, value: Any
+    ) -> None:
+        pass
+
+    async def get_value(self, runtime_id: str, namespace: str, key: str) -> Any:
+        return None
+
+
+class DeprecatedCreateAliasManager(UiPathResumeTriggerProtocol):
+    """Trigger manager that relies on the protocol's singular create alias."""
+
+    def __init__(self) -> None:
+        self.created_values: list[Any] = []
+        self.trigger_count = 1
+
+    async def create_triggers(self, suspend_value: Any) -> list[UiPathResumeTrigger]:
+        self.created_values.append(suspend_value)
+        return [
+            UiPathResumeTrigger(
+                interrupt_id="",
+                trigger_type=UiPathResumeTriggerType.TASK,
+                payload=suspend_value,
+            )
+            for _ in range(self.trigger_count)
+        ]
+
+    async def read_trigger(self, trigger: UiPathResumeTrigger) -> Any | None:
         return None
 
 
@@ -134,6 +246,11 @@ def make_trigger_manager_mock() -> UiPathResumeTriggerProtocol:
         raise UiPathPendingTriggerError(ErrorCategory.USER, "Trigger not fired yet")
 
     manager.create_trigger = AsyncMock(side_effect=create_trigger_impl)
+
+    async def create_triggers_impl(data: dict[str, Any]) -> list[UiPathResumeTrigger]:
+        return [await manager.create_trigger(data)]
+
+    manager.create_triggers = AsyncMock(side_effect=create_triggers_impl)
     manager.read_trigger = AsyncMock(side_effect=read_trigger_default)
 
     return cast(UiPathResumeTriggerProtocol, manager)
@@ -141,12 +258,199 @@ def make_trigger_manager_mock() -> UiPathResumeTriggerProtocol:
 
 class TestResumableRuntime:
     @pytest.mark.asyncio
+    async def test_delete_trigger_alias_delegates_to_delete_triggers(self) -> None:
+        """Deprecated singular delete API delegates to the plural API."""
+
+        storage = DeprecatedDeleteAliasStorage()
+        trigger = UiPathResumeTrigger(
+            interrupt_id="int-1",
+            trigger_type=UiPathResumeTriggerType.TASK,
+        )
+
+        await storage.delete_trigger("runtime-1", trigger)
+
+        assert storage.deleted_triggers == [trigger]
+
+    @pytest.mark.asyncio
+    async def test_create_trigger_alias_delegates_to_create_triggers(self) -> None:
+        """Deprecated singular create API delegates to the plural API."""
+
+        manager = DeprecatedCreateAliasManager()
+
+        trigger = await manager.create_trigger({"action": "approve"})
+
+        assert trigger.payload == {"action": "approve"}
+        assert manager.created_values == [{"action": "approve"}]
+
+    @pytest.mark.asyncio
+    async def test_create_trigger_alias_rejects_multiple_triggers(self) -> None:
+        """Deprecated singular create API fails if plural API returns siblings."""
+
+        manager = DeprecatedCreateAliasManager()
+        manager.trigger_count = 2
+
+        with pytest.raises(UiPathRuntimeError, match="Use create_triggers"):
+            await manager.create_trigger({"action": "approve"})
+
+    def test_with_trigger_metadata_merges_existing_uipath_metadata(self) -> None:
+        """Existing UiPath metadata is preserved when trigger metadata is added."""
+
+        storage = StatefulStorageMock()
+        trigger_manager = make_trigger_manager_mock()
+        resumable = UiPathResumableRuntime(
+            delegate=SiblingTriggerMockRuntime(),
+            storage=storage,
+            trigger_manager=trigger_manager,
+            runtime_id="runtime-1",
+        )
+        trigger = UiPathResumeTrigger(
+            interrupt_id="int-1",
+            trigger_type=UiPathResumeTriggerType.TIMER,
+            trigger_name=UiPathResumeTriggerName.TIMER,
+        )
+
+        result = resumable._with_trigger_metadata(
+            trigger,
+            {"__uipath": {"kind": "timeout", "timeout": 10}, "value": "done"},
+        )
+
+        assert result == {
+            "__uipath": {
+                "kind": "timeout",
+                "timeout": 10,
+                "triggerType": UiPathResumeTriggerType.TIMER.value,
+                "triggerName": UiPathResumeTriggerName.TIMER.value,
+            },
+            "value": "done",
+        }
+
+    def test_with_trigger_metadata_wraps_non_mapping_data(self) -> None:
+        """Non-mapping resume values are wrapped with trigger metadata."""
+
+        storage = StatefulStorageMock()
+        trigger_manager = make_trigger_manager_mock()
+        resumable = UiPathResumableRuntime(
+            delegate=SiblingTriggerMockRuntime(),
+            storage=storage,
+            trigger_manager=trigger_manager,
+            runtime_id="runtime-1",
+        )
+        trigger = Mock(
+            interrupt_id="int-1",
+            trigger_type="CustomType",
+            trigger_name="CustomName",
+        )
+
+        result = resumable._with_trigger_metadata(
+            cast(UiPathResumeTrigger, trigger), "approved"
+        )
+
+        assert result == {
+            "__uipath": {
+                "triggerType": "CustomType",
+                "triggerName": "CustomName",
+            },
+            "value": "approved",
+        }
+
+    @pytest.mark.asyncio
+    async def test_restore_resume_input_deletes_single_trigger_for_explicit_input(
+        self,
+    ) -> None:
+        """Explicit resume input clears the only stored trigger."""
+
+        storage = StatefulStorageMock()
+        storage.triggers = [
+            UiPathResumeTrigger(
+                interrupt_id="int-1",
+                trigger_type=UiPathResumeTriggerType.TASK,
+            )
+        ]
+        resumable = UiPathResumableRuntime(
+            delegate=SiblingTriggerMockRuntime(),
+            storage=storage,
+            trigger_manager=make_trigger_manager_mock(),
+            runtime_id="runtime-1",
+        )
+
+        result = await resumable._restore_resume_input({"int-1": {"approved": True}})
+
+        assert result == {"int-1": {"approved": True}}
+        assert storage.triggers == []
+
+    @pytest.mark.asyncio
+    async def test_restore_resume_input_deletes_matching_trigger_for_explicit_input(
+        self,
+    ) -> None:
+        """Explicit resume input clears only matching stored triggers."""
+
+        trigger_1 = UiPathResumeTrigger(
+            interrupt_id="int-1",
+            trigger_type=UiPathResumeTriggerType.TASK,
+        )
+        trigger_2 = UiPathResumeTrigger(
+            interrupt_id="int-2",
+            trigger_type=UiPathResumeTriggerType.TASK,
+        )
+        storage = StatefulStorageMock()
+        storage.triggers = [trigger_1, trigger_2]
+        resumable = UiPathResumableRuntime(
+            delegate=SiblingTriggerMockRuntime(),
+            storage=storage,
+            trigger_manager=make_trigger_manager_mock(),
+            runtime_id="runtime-1",
+        )
+
+        result = await resumable._restore_resume_input({"int-2": {"approved": True}})
+
+        assert result == {"int-2": {"approved": True}}
+        assert storage.triggers == [trigger_1]
+
+    @pytest.mark.asyncio
+    async def test_build_resume_map_skips_duplicate_pollable_trigger(self) -> None:
+        """Duplicate pollable triggers for one interrupt are read once."""
+
+        trigger_1 = UiPathResumeTrigger(
+            interrupt_id="int-1",
+            trigger_type=UiPathResumeTriggerType.TASK,
+        )
+        trigger_2 = UiPathResumeTrigger(
+            interrupt_id="int-1",
+            trigger_type=UiPathResumeTriggerType.JOB,
+        )
+        storage = StatefulStorageMock()
+        storage.triggers = [trigger_1, trigger_2]
+        trigger_manager = make_trigger_manager_mock()
+        read_trigger_mock = AsyncMock(return_value="approved")
+        cast(Any, trigger_manager).read_trigger = read_trigger_mock
+        resumable = UiPathResumableRuntime(
+            delegate=SiblingTriggerMockRuntime(),
+            storage=storage,
+            trigger_manager=trigger_manager,
+            runtime_id="runtime-1",
+        )
+
+        result = await resumable._build_resume_map([trigger_1, trigger_2])
+
+        assert result == {
+            "int-1": {
+                "__uipath": {
+                    "triggerType": UiPathResumeTriggerType.TASK.value,
+                    "triggerName": "Unknown",
+                },
+                "value": "approved",
+            }
+        }
+        read_trigger_mock.assert_awaited_once_with(trigger_1)
+        assert storage.triggers == []
+
+    @pytest.mark.asyncio
     async def test_resumable_creates_multiple_triggers_on_first_suspension(
         self,
     ) -> None:
         """First suspension with parallel branches should create multiple triggers."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -179,7 +483,7 @@ class TestResumableRuntime:
     async def test_resumable_adds_only_new_triggers_on_partial_resume(self) -> None:
         """Partial resume should keep pending trigger and add only new ones."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -222,7 +526,7 @@ class TestResumableRuntime:
     async def test_resumable_completes_after_all_triggers_resolved(self) -> None:
         """After all triggers resolved, execution should complete successfully."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -269,7 +573,7 @@ class TestResumableRuntime:
     async def test_resumable_auto_resumes_when_triggers_already_fired(self) -> None:
         """When triggers are already fired during suspension, runtime should auto-resume."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -308,7 +612,7 @@ class TestResumableRuntime:
     async def test_resumable_auto_resumes_partial_fired_triggers(self) -> None:
         """When only some triggers are fired during suspension, auto-resume with those."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -344,7 +648,7 @@ class TestResumableRuntime:
     async def test_resumable_auto_resumes_multiple_times(self) -> None:
         """When triggers keep being fired immediately, keep auto-resuming until complete."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -389,7 +693,7 @@ class TestResumableRuntime:
     async def test_resumable_stream_auto_resumes_when_triggers_fired(self) -> None:
         """Stream should auto-resume when triggers are already fired."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -426,7 +730,7 @@ class TestResumableRuntime:
     async def test_resumable_no_auto_resume_when_all_triggers_pending(self) -> None:
         """When all triggers are pending, should NOT auto-resume."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -457,7 +761,7 @@ class TestResumableRuntime:
     async def test_resumable_skips_api_triggers_on_auto_resume_check(self) -> None:
         """API triggers should be skipped when checking for auto-resume after suspension."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -508,7 +812,7 @@ class TestResumableRuntime:
         404 and fault the run. They should behave like API triggers here.
         """
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -552,7 +856,7 @@ class TestResumableRuntime:
     async def test_resumable_skips_timer_triggers_on_auto_resume_check(self) -> None:
         """Timer triggers should be skipped when checking for auto-resume."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -595,7 +899,7 @@ class TestResumableRuntime:
     ) -> None:
         """Mixed triggers: TASK triggers should trigger auto-resume, API triggers should not."""
 
-        runtime_impl = MultiTriggerMockRuntime()
+        runtime_impl = SiblingTriggerMockRuntime()
         storage = StatefulStorageMock()
         trigger_manager = make_trigger_manager_mock()
 
@@ -640,3 +944,67 @@ class TestResumableRuntime:
 
         # Delegate should have been executed twice (initial + auto-resume for TASK trigger)
         assert runtime_impl.execution_count == 2
+
+    @pytest.mark.asyncio
+    async def test_resumable_removes_sibling_triggers_when_one_trigger_fires(
+        self,
+    ) -> None:
+        """When one trigger fires, sibling triggers must not leak forward."""
+
+        runtime_impl = MultiTriggerMockRuntime()
+        storage = StatefulStorageMock()
+        trigger_manager = make_trigger_manager_mock()
+
+        async def create_sibling_triggers(
+            data: dict[str, Any],
+        ) -> list[UiPathResumeTrigger]:
+            return [
+                UiPathResumeTrigger(
+                    interrupt_id="",  # Will be set by resumable runtime
+                    trigger_type=UiPathResumeTriggerType.JOB,
+                    payload={"source": data["process"]},
+                ),
+                UiPathResumeTrigger(
+                    interrupt_id="",  # Will be set by resumable runtime
+                    trigger_type=UiPathResumeTriggerType.TIMER,
+                    payload={"source": data["process"]},
+                ),
+            ]
+
+        create_triggers_mock = AsyncMock(side_effect=create_sibling_triggers)
+        cast(Any, trigger_manager).create_triggers = create_triggers_mock
+
+        async def read_trigger_impl(trigger: UiPathResumeTrigger) -> dict[str, Any]:
+            if (
+                trigger.interrupt_id == "child-1"
+                and trigger.trigger_type == UiPathResumeTriggerType.JOB
+            ):
+                return {"completed": True}
+            raise UiPathPendingTriggerError(ErrorCategory.USER, "still pending")
+
+        read_trigger_mock = AsyncMock(side_effect=read_trigger_impl)
+        cast(Any, trigger_manager).read_trigger = read_trigger_mock
+
+        resumable = UiPathResumableRuntime(
+            delegate=runtime_impl,
+            storage=storage,
+            trigger_manager=trigger_manager,
+            runtime_id="runtime-1",
+        )
+
+        result = await resumable.execute({})
+
+        assert result.status == UiPathRuntimeStatus.SUSPENDED
+        assert result.triggers is not None
+        assert {t.interrupt_id for t in result.triggers} == {"child-2"}
+        assert len(result.triggers) == 2
+        assert {t.trigger_type for t in result.triggers} == {
+            UiPathResumeTriggerType.JOB,
+            UiPathResumeTriggerType.TIMER,
+        }
+        assert runtime_impl.execution_count == 2
+        assert create_triggers_mock.await_count == 2
+        assert read_trigger_mock.await_count == 2
+
+        saved_triggers = await storage.get_triggers("runtime-1")
+        assert {t.interrupt_id for t in saved_triggers} == {"child-2"}

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.8"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary
- add `create_triggers` to the resumable trigger creator protocol
- persist all triggers returned for one interrupt so multiple resume conditions can race
- add `__uipath` trigger metadata to composite interrupt resume values so callers can identify which sibling fired
- keep sibling triggers scoped by interrupt id so when one fires the remaining siblings do not leak into later suspensions
- Force cross-repo uv resolves to use the runtime wheel under test. (similar to https://github.com/UiPath/uipath-python/pull/1723)

Depends on: https://github.com/UiPath/uipath-python/pull/1768 and https://github.com/UiPath/uipath-python/pull/1773

## Interrupt Shape

This enables one interrupt id to be backed by multiple sibling resume triggers. Platform/langchain can expose this as a race between conditions, equivalent to `Task.WhenAny`:

```python
result = interrupt([
    InvokeProcess(...),
    WaitUntil(...),
])
```

Equivalent shape:

```csharp
var result = await Task.WhenAny(
    invokeProcessTask,
    timeoutTask
);
```

At runtime, both triggers are persisted for the same interrupt id. When one sibling fires, runtime resumes that interrupt once, annotates composite resume values with `__uipath` trigger metadata, and deletes the remaining sibling triggers for that interrupt.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.12.0.dev1001380615",

  # Any version from PR
  "uipath-runtime>=0.12.0.dev1001380000,<0.12.0.dev1001390000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```
