### PR TITLE
feat(runtime): add agent_type + agent_framework fields to UiPathRuntimeFactorySettings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.11.6"
+version = "0.11.7"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/factory.py
+++ b/src/uipath/runtime/factory.py
@@ -20,7 +20,7 @@ class UiPathRuntimeFactorySettings(BaseModel):
     trace_settings: UiPathTraceSettings | None = None
 
     agent_type: str | None = None
-    
+
     agent_framework: str | None = None
 
 

--- a/src/uipath/runtime/factory.py
+++ b/src/uipath/runtime/factory.py
@@ -19,6 +19,10 @@ class UiPathRuntimeFactorySettings(BaseModel):
 
     trace_settings: UiPathTraceSettings | None = None
 
+    agent_type: str | None = None
+    
+    agent_framework: str | None = None
+
 
 class UiPathRuntimeFactoryProtocol(
     UiPathDisposableProtocol,

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.6"
+version = "0.11.7"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

Adds two optional string fields to `UiPathRuntimeFactorySettings` so framework adapters can carry their own identity (agent type + framework name) through the factory-settings surface. Downstream consumers that need those labels — governance audit events, tracing spans, telemetry envelopes — can read them off `settings` instead of sniffing the filesystem for `langgraph.json` / `llama_index.json` / etc.

```python
class UiPathRuntimeFactorySettings(BaseModel):
    trace_settings: UiPathTraceSettings | None = None
    agent_type: str | None = None       # new
    agent_framework: str | None = None  # new
```

Both fields default to `None` so every existing adapter and consumer keeps working unchanged. Adapters that want the labels populate them at registration time (e.g. `agent_framework="langgraph"`) and the host reads them back through the factory registry lookup.

## Scope

**3 files changed, +6/-2**

| File | Change |
|---|---|
| `src/uipath/runtime/factory.py` | Two new `str \| None = None` fields on `UiPathRuntimeFactorySettings` |
| `pyproject.toml` | Version bump `0.11.6` → `0.11.7` |
| `uv.lock` | Lockfile refresh for the version bump |

## Backward compatibility

Additive only — both fields have a `None` default:
- Existing adapters that don't set them continue to work with zero edits
- Consumers that read `settings.agent_type` / `settings.agent_framework` must handle `None`
- No API removals, no signature changes, no behavioral changes on the existing surface

## Test plan

- [x] `uv run pytest` — full suite green locally
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy --config-file pyproject.toml .` — clean

## Follow-ups (separate PRs, not in this one)

- Framework adapters (`uipath-langchain`, `uipath-llamaindex`, `uipath-openai-agents`, etc.) will populate `agent_framework` on their factory registration in follow-up commits in their own repos
- The host CLI's `_governance_bootstrap.py` can drop its filesystem-sniffing `detect_agent_framework` once at least one adapter ships the label; until then it keeps working as a fallback

## Development Package

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-runtime==0.11.7.dev1001410600",

  # Any version from this PR:
  "uipath-runtime>=0.11.7.dev1001410000,<0.11.7.dev1001420000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-runtime = { index = "testpypi" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)