### PR TITLE
feat: expose conversationalService.enableOutputs FPS flag on context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.11.7"
+version = "0.11.8"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -53,7 +53,7 @@ class UiPathRuntimeContext(BaseModel):
     )
     conversational_outputs_enabled: bool = Field(
         False,
-        description=("Whether conversational agent should generate structured outputs on its turn."),
+        description="Whether conversational agent output-generation is enabled."
     )
     conversational_user_id: str | None = Field(
         None,

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -51,6 +51,10 @@ class UiPathRuntimeContext(BaseModel):
         True,
         description="Whether to emit the exchange end event for CAS",
     )
+    conversational_outputs_enabled: bool = Field(
+        False,
+        description=("Whether conversational agent should generate structured outputs on its turn."),
+    )
     conversational_user_id: str | None = Field(
         None,
         description="Conversation owner id for CAS (a real cloud user id or a synthetic user id)",
@@ -408,6 +412,7 @@ class UiPathRuntimeContext(BaseModel):
             "conversationalService.exchangeId": "exchange_id",
             "conversationalService.messageId": "message_id",
             "conversationalService.endExchange": "end_exchange",
+            "conversationalService.enableOutputs": "conversational_outputs_enabled",
             "conversationalService.conversationalUserId": "conversational_user_id",
             "mcpServer.id": "mcp_server_id",
             "mcpServer.slug": "mcp_server_slug",

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -52,8 +52,7 @@ class UiPathRuntimeContext(BaseModel):
         description="Whether to emit the exchange end event for CAS",
     )
     conversational_outputs_enabled: bool = Field(
-        False,
-        description="Whether conversational agent output-generation is enabled."
+        False, description="Whether conversational agent output-generation is enabled."
     )
     conversational_user_id: str | None = Field(
         None,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -183,6 +183,7 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
             "conversationalService.conversationId": "conv-123",
             "conversationalService.exchangeId": "ex-456",
             "conversationalService.messageId": "msg-789",
+            "conversationalService.enableOutputs": True,
             "conversationalService.conversationalUserId": "owner-guid",
             "mcpServer.id": "server-id-123",
             "mcpServer.slug": "my-mcp-server",
@@ -196,9 +197,28 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
     assert ctx.conversation_id == "conv-123"
     assert ctx.exchange_id == "ex-456"
     assert ctx.message_id == "msg-789"
+    assert ctx.conversational_outputs_enabled is True
     assert ctx.conversational_user_id == "owner-guid"
     assert ctx.mcp_server_id == "server-id-123"
     assert ctx.mcp_server_slug == "my-mcp-server"
+
+
+def test_from_config_conversational_outputs_enabled_defaults_false(
+    tmp_path: Path,
+) -> None:
+    """When enableOutputs isn't in fpsProperties, the field defaults to False —
+    legacy safe behavior for pre-migration conversational agents."""
+    cfg = {
+        "fpsProperties": {
+            "conversationalService.conversationId": "conv-legacy",
+        }
+    }
+    config_path = tmp_path / "uipath.json"
+    config_path.write_text(json.dumps(cfg))
+
+    ctx = UiPathRuntimeContext.from_config(config_path=str(config_path))
+
+    assert ctx.conversational_outputs_enabled is False
 
 
 def test_from_config_loads_runtime_and_fps_properties(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.7"
+version = "0.11.8"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

Add a new field on `UiPathRuntimeContext` that surfaces the `conversationalService.enableOutputs` FPS property, so downstream layers (uipath-agents) can gate the new "conversational structured outputs" feature
on whether the service has opted in.

This is primarily to ensure only Flow-started agent-jobs have conversational output feature working at the moment. For the regular conversational-agent jobs (started to serve a chat) there's no point of generating outputs as they aren't surfaced to the user.

## Related PRs

Part of a coordinated four-repo change. Each PR is independently reviewable, but they land together:

- **uipath-runtime-python** https://github.com/UiPath/uipath-runtime-python/pull/142 — surfaces the `conversationalService.enableOutputs` FPS flag on `UiPathRuntimeContext`.
- **uipath-python** https://github.com/UiPath/uipath-python/pull/1785 — adds the `set_conversational_output` flow-control tool + generate-output prompt primitives.
- **uipath-langchain-python** https://github.com/UiPath/uipath-langchain-python/pull/965 — implements the `GENERATE_CONVERSATIONAL_OUTPUT` graph node, router path, and terminate extraction (the main change).
- **uipath-agents-python** https://github.com/UiPath/uipath-agents-python/pull/588 — Gates custom outputs on the FPS flag + agent-version.

## Test plan

- [x] \`uv run pytest tests/test_context.py\` (23 tests pass)
- [x] \`ruff check\` + \`ruff format --check\` clean
