### PR TITLE
fix: forward hydration runtime delegate attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.11.8"
+version = "0.11.9"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/workspace/hydration.py
+++ b/src/uipath/runtime/workspace/hydration.py
@@ -94,6 +94,10 @@ class HydrationRuntime:
         finally:
             await self.workspace.dispose()
 
+    def __getattr__(self, name: str) -> Any:
+        """Forward unknown attributes to the wrapped runtime."""
+        return getattr(self.delegate, name)
+
     async def _hydrate(self) -> None:
         registry = await self.registry_store.load()
         hydrated = await self.hydrator.hydrate(registry)

--- a/tests/workspace/test_workspace_hydration.py
+++ b/tests/workspace/test_workspace_hydration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import uuid
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, cast
 
 import pytest
 
@@ -100,6 +100,7 @@ class WritingRuntime:
         self.workspace_path = workspace_path
         self.status = status
         self.disposed = False
+        self.runtime_id = "runtime-1"
 
     async def execute(
         self,
@@ -255,6 +256,24 @@ async def test_hydrate_skips_unchanged_local_file(tmp_path: Path) -> None:
     await hydrator.hydrate(registry)
 
     assert attachments.downloads == 0
+
+
+def test_hydration_runtime_forwards_delegate_attributes(tmp_path: Path) -> None:
+    workspace = Workspace.create(tmp_path / "workspace")
+    delegate = WritingRuntime(workspace.path, UiPathRuntimeStatus.SUCCESSFUL)
+    runtime = HydrationRuntime(
+        delegate,
+        workspace=workspace,
+        hydrator=WorkspaceHydrator(
+            workspace_path=workspace.path,
+            attachments=FakeAttachments(),
+        ),
+        registry_store=WorkspaceRegistryStore(MemoryStorage(), "runtime-1"),
+    )
+
+    forwarded_runtime = cast(Any, runtime)
+    assert forwarded_runtime.runtime_id == "runtime-1"
+    assert forwarded_runtime.workspace_path == workspace.path
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.8"
+version = "0.11.9"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary
- forward unknown HydrationRuntime attributes to the wrapped delegate runtime
- add regression coverage for runtime_id-style delegate attributes

## Validation
- uv run ruff format src/uipath/runtime/workspace/hydration.py tests/workspace/test_workspace_hydration.py
- uv run ruff check src/uipath/runtime/workspace/hydration.py tests/workspace/test_workspace_hydration.py
- uv run mypy --config-file pyproject.toml .
- uv run pytest tests/workspace/test_workspace_hydration.py
- uv run pytest