### PR TITLE
feat: add isTransactionRoot to UiPathRuntimeSchema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.12.1"
+version = "0.12.2"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/schema.py
+++ b/src/uipath/runtime/schema.py
@@ -59,6 +59,12 @@ class UiPathRuntimeSchema(BaseModel):
     type: str = Field(..., alias="type")
     input: dict[str, Any] = Field(..., alias="input")
     output: dict[str, Any] = Field(..., alias="output")
+    is_transaction_root: bool | None = Field(
+        None,
+        alias="isTransactionRoot",
+        description="Whether this entrypoint is a transaction root "
+        "(set for vertical-solution projects)",
+    )
     graph: UiPathRuntimeGraph | None = Field(
         None, description="Runtime graph structure for debugging"
     )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from uipath.runtime.schema import (
+    UiPathRuntimeSchema,
     transform_attachments,
     transform_nullable_types,
     transform_references,
@@ -295,3 +296,38 @@ class TestSchemaGenerationHelpers:
         }
 
         assert result == expected
+
+
+class TestUiPathRuntimeSchema:
+    def _make_schema(self, **kwargs: Any) -> UiPathRuntimeSchema:
+        return UiPathRuntimeSchema(
+            filePath="main.py",
+            uniqueId="00000000-0000-0000-0000-000000000001",
+            type="function",
+            input={},
+            output={},
+            **kwargs,
+        )
+
+    def test_is_transaction_root_omitted_when_unset(self):
+        """Unset flag must not appear in the serialized entrypoint (bool? on consumers)."""
+        schema = self._make_schema()
+
+        dumped = schema.model_dump(by_alias=True, exclude_unset=True)
+
+        assert "isTransactionRoot" not in dumped
+
+    def test_is_transaction_root_serializes_by_alias(self):
+        """The flag set via the python name serializes under its camelCase alias."""
+        schema = self._make_schema()
+        schema.is_transaction_root = True
+
+        dumped = schema.model_dump(by_alias=True, exclude_unset=True)
+
+        assert dumped["isTransactionRoot"] is True
+
+    def test_is_transaction_root_validates_from_alias(self):
+        """The flag round-trips when read back from entry-points.json content."""
+        schema = self._make_schema(isTransactionRoot=True)
+
+        assert schema.is_transaction_root is True

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

- Declare `is_transaction_root` (serialized as `isTransactionRoot`) as an optional field on `UiPathRuntimeSchema`.
- When unset it is omitted from `model_dump(by_alias=True, exclude_unset=True)`, matching the nullable (`bool?`) contract of platform consumers reading `entry-points.json`.
- Bump version to 0.12.2.

## Motivation

`uipath init` (uipath-python) stamps `isTransactionRoot: true` on every entrypoint in `entry-points.json` when `uipath.json` has `runtimeOptions._uipathVerticalSolution: true`.

## Tests

- 3 new tests in `tests/test_schema.py`: unset → key absent, set via python name → serializes under the camelCase alias, validates from alias on read-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)