### PR TITLE
feat: add conversational_run_as_me to runtime context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.12.2"
+version = "0.12.3"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -58,6 +58,10 @@ class UiPathRuntimeContext(BaseModel):
         None,
         description="Conversation owner id for CAS (a real cloud user id or a synthetic user id)",
     )
+    conversational_run_as_me: bool = Field(
+        False,
+        description="Whether the conversational agent job is running with RunAsMe: true.",
+    )
     voice_mode: Literal["session", "maestro_flow"] | None = Field(
         None, description="Voice job type for CAS"
     )
@@ -413,6 +417,7 @@ class UiPathRuntimeContext(BaseModel):
             "conversationalService.endExchange": "end_exchange",
             "conversationalService.enableOutputs": "conversational_outputs_enabled",
             "conversationalService.conversationalUserId": "conversational_user_id",
+            "conversationalService.runAsMe": "conversational_run_as_me",
             "mcpServer.id": "mcp_server_id",
             "mcpServer.slug": "mcp_server_slug",
             "voice.mode": "voice_mode",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -185,6 +185,7 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
             "conversationalService.messageId": "msg-789",
             "conversationalService.enableOutputs": True,
             "conversationalService.conversationalUserId": "owner-guid",
+            "conversationalService.runAsMe": True,
             "mcpServer.id": "server-id-123",
             "mcpServer.slug": "my-mcp-server",
         }
@@ -199,8 +200,26 @@ def test_from_config_extracts_fps_properties_without_runtime(tmp_path: Path) -> 
     assert ctx.message_id == "msg-789"
     assert ctx.conversational_outputs_enabled is True
     assert ctx.conversational_user_id == "owner-guid"
+    assert ctx.conversational_run_as_me is True
     assert ctx.mcp_server_id == "server-id-123"
     assert ctx.mcp_server_slug == "my-mcp-server"
+
+
+def test_conversational_run_as_me_defaults_false_when_fps_property_absent(
+    tmp_path: Path,
+) -> None:
+    """conversational_run_as_me defaults to False when the fps key is missing."""
+    cfg = {
+        "fpsProperties": {
+            "conversationalService.conversationId": "conv-123",
+        }
+    }
+    config_path = tmp_path / "uipath.json"
+    config_path.write_text(json.dumps(cfg))
+
+    ctx = UiPathRuntimeContext.from_config(config_path=str(config_path))
+
+    assert ctx.conversational_run_as_me is False
 
 
 def test_from_config_conversational_outputs_enabled_defaults_false(

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

- Exposes `fpsProperties.conversationalService.runAsMe` on `UiPathRuntimeContext.conversational_run_as_me` so downstream layers can mirror the parent conversational agent job's `RunAsMe` flag onto child process / API-workflow tool invocations.
- Replaces the brittle token `sub_type == "user"` inspection in the langchain tool factory, which was misclassifying user tokens and preventing `RunAsMe` from propagating correctly to child jobs.
- Bumps `uipath-runtime` to `0.12.3`.

## Related PRs

- Langchain (accepts `run_as_me` on `create_tools_from_resources`): UiPath/uipath-langchain-python#981
- Agents (threads the value from this context field into the tool factory): UiPath/uipath-agents-python#618

## Test plan

- [x] `uv run pytest tests/test_context.py` — 26 passed (includes the new `test_conversational_run_as_me_defaults_false_when_fps_property_absent` and the extended `test_from_config_extracts_fps_properties_without_runtime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)