### PR TITLE
feat: support lazy workspace hydrator creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.12.3"
+version = "0.12.4"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/workspace/hydration.py
+++ b/src/uipath/runtime/workspace/hydration.py
@@ -1,7 +1,7 @@
 """Runtime wrapper for workspace hydration."""
 
 from enum import Enum
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Callable, overload
 
 from uipath.runtime.base import (
     UiPathExecuteOptions,
@@ -27,6 +27,7 @@ class HydrationPolicy(str, Enum):
 class HydrationRuntime:
     """Wraps a runtime with hydrate-before and dehydrate-after behavior."""
 
+    @overload
     def __init__(
         self,
         delegate: UiPathRuntimeProtocol,
@@ -34,14 +35,49 @@ class HydrationRuntime:
         workspace: Workspace,
         hydrator: WorkspaceHydrator,
         registry_store: WorkspaceRegistryStore,
+        hydrator_factory: None = None,
         policy: HydrationPolicy = HydrationPolicy.SUSPEND_ONLY,
-    ):
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        delegate: UiPathRuntimeProtocol,
+        *,
+        workspace: Workspace,
+        hydrator: None = None,
+        registry_store: WorkspaceRegistryStore,
+        hydrator_factory: Callable[[], WorkspaceHydrator],
+        policy: HydrationPolicy = HydrationPolicy.SUSPEND_ONLY,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        delegate: UiPathRuntimeProtocol,
+        *,
+        workspace: Workspace,
+        hydrator: WorkspaceHydrator | None = None,
+        registry_store: WorkspaceRegistryStore,
+        hydrator_factory: Callable[[], WorkspaceHydrator] | None = None,
+        policy: HydrationPolicy = HydrationPolicy.SUSPEND_ONLY,
+    ) -> None:
         """Initialize the hydration wrapper."""
+        if (hydrator is None) == (hydrator_factory is None):
+            raise ValueError("Provide exactly one of hydrator or hydrator_factory")
+
         self.delegate = delegate
         self.workspace = workspace
         self.hydrator = hydrator
+        self._hydrator_factory = hydrator_factory
         self.registry_store = registry_store
         self.policy = policy
+
+    def _get_hydrator(self) -> WorkspaceHydrator:
+        if self.hydrator is None:
+            if self._hydrator_factory is None:  # pragma: no cover - constructor guard
+                raise RuntimeError("Hydrator is not configured")
+            self.hydrator = self._hydrator_factory()
+        return self.hydrator
 
     async def execute(
         self,
@@ -96,7 +132,7 @@ class HydrationRuntime:
 
     async def _hydrate(self) -> None:
         registry = await self.registry_store.load()
-        hydrated = await self.hydrator.hydrate(registry)
+        hydrated = await self._get_hydrator().hydrate(registry)
         if hydrated != registry:
             await self.registry_store.save(hydrated)
 
@@ -106,7 +142,7 @@ class HydrationRuntime:
 
     async def _persist(self) -> None:
         registry = await self.registry_store.load()
-        dehydrated = await self.hydrator.dehydrate(registry)
+        dehydrated = await self._get_hydrator().dehydrate(registry)
         await self.registry_store.save(dehydrated)
 
     def _should_dehydrate(self, result: UiPathRuntimeResult) -> bool:

--- a/tests/workspace/test_workspace_hydration.py
+++ b/tests/workspace/test_workspace_hydration.py
@@ -125,6 +125,20 @@ class WritingRuntime:
         self.disposed = True
 
 
+class SchemaRuntime(WritingRuntime):
+    def __init__(self, workspace_path: Path) -> None:
+        super().__init__(workspace_path, UiPathRuntimeStatus.SUCCESSFUL)
+
+    async def get_schema(self) -> UiPathRuntimeSchema:
+        return UiPathRuntimeSchema(
+            filePath="agent.py",
+            uniqueId="agent",
+            type="agent",
+            input={},
+            output={},
+        )
+
+
 @pytest.mark.asyncio
 async def test_dehydrate_uploads_changed_files_and_saves_registry(
     tmp_path: Path,
@@ -156,6 +170,94 @@ async def test_dehydrate_uploads_changed_files_and_saves_registry(
     assert registry["notes.txt"]["attachment_name"] == ".uipath-workspace~1notes.txt"
     assert attachments.uploads == 1
     assert len(jobs.links) == 1
+
+
+@pytest.mark.asyncio
+async def test_hydrator_factory_is_deferred_and_cached(tmp_path: Path) -> None:
+    workspace = Workspace.create(tmp_path / "workspace")
+    attachments = FakeAttachments()
+    storage = MemoryStorage()
+    factory_calls = 0
+
+    def create_hydrator() -> WorkspaceHydrator:
+        nonlocal factory_calls
+        factory_calls += 1
+        return WorkspaceHydrator(
+            workspace_path=workspace.path,
+            attachments=attachments,
+        )
+
+    runtime = HydrationRuntime(
+        SchemaRuntime(workspace.path),
+        workspace=workspace,
+        hydrator_factory=create_hydrator,
+        registry_store=WorkspaceRegistryStore(storage, "runtime-1"),
+    )
+
+    await runtime.get_schema()
+    assert factory_calls == 0
+    assert runtime.hydrator is None
+
+    await runtime.execute({})
+    assert [event async for event in runtime.stream({})]
+
+    assert factory_calls == 1
+    assert runtime.hydrator is not None
+    assert runtime.hydrator.attachments is attachments
+
+
+@pytest.mark.asyncio
+async def test_dispose_does_not_create_hydrator(tmp_path: Path) -> None:
+    workspace = Workspace.create(tmp_path / "workspace")
+    factory_calls = 0
+
+    def create_hydrator() -> WorkspaceHydrator:
+        nonlocal factory_calls
+        factory_calls += 1
+        return WorkspaceHydrator(
+            workspace_path=workspace.path,
+            attachments=FakeAttachments(),
+        )
+
+    delegate = SchemaRuntime(workspace.path)
+    runtime = HydrationRuntime(
+        delegate,
+        workspace=workspace,
+        hydrator_factory=create_hydrator,
+        registry_store=WorkspaceRegistryStore(MemoryStorage(), "runtime-1"),
+    )
+
+    await runtime.dispose()
+
+    assert delegate.disposed
+    assert factory_calls == 0
+
+
+def test_hydration_runtime_requires_exactly_one_hydrator_source(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.create(tmp_path / "workspace")
+    hydrator = WorkspaceHydrator(
+        workspace_path=workspace.path,
+        attachments=FakeAttachments(),
+    )
+    registry_store = WorkspaceRegistryStore(MemoryStorage(), "runtime-1")
+
+    with pytest.raises(ValueError, match="exactly one"):
+        HydrationRuntime(  # type: ignore[call-overload]
+            WritingRuntime(workspace.path, UiPathRuntimeStatus.SUCCESSFUL),
+            workspace=workspace,
+            registry_store=registry_store,
+        )
+
+    with pytest.raises(ValueError, match="exactly one"):
+        HydrationRuntime(  # type: ignore[call-overload]
+            WritingRuntime(workspace.path, UiPathRuntimeStatus.SUCCESSFUL),
+            workspace=workspace,
+            hydrator=hydrator,
+            hydrator_factory=lambda: hydrator,
+            registry_store=registry_store,
+        )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.12.3"
+version = "0.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Why
`HydratorRuntime` used by deep agents requires an eagerly initialized hydrator, which requires initializing the UiPath SDK. This introduces the need for the user to be authenticated even when running `uipath init`, which is different to what is required for non-deep agents. Adding the option of lazy initialization via a factory lets `uipath init` remain auth free.

## Summary

- add an optional `hydrator_factory` to defer workspace hydrator construction until execution
- preserve existing eager `hydrator` usage and enforce exactly one hydrator source, can remove in a future major release if we decide to move exclusively to the lazy hydrator
- keep schema discovery, disposal, and pre-execution hydrator inspection free of factory side effects
- bump `uipath-runtime` to `0.12.4`

## Testing

- `.venv/bin/pytest --no-cov -p no:cacheprovider` (379 passed)
- `MYPY_CACHE_DIR=/tmp/mypy-cache-runtime .venv/bin/mypy --config-file pyproject.toml .`
- `RUFF_CACHE_DIR=/tmp/ruff-cache-runtime .venv/bin/ruff check src tests`
- `RUFF_CACHE_DIR=/tmp/ruff-cache-runtime .venv/bin/ruff format --check src tests`
- `UV_CACHE_DIR=/tmp/uv-cache-runtime uv lock --check`