### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
         with:
           configuration-path: '.github/labeler.yml'
           sync-labels: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
 
     needs:
       - lint
@@ -32,15 +32,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 
@@ -51,14 +51,14 @@ jobs:
         run: uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-dists
           path: dist/
 
   pypi-publish:
     name: Upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi
 
     needs:
@@ -69,10 +69,10 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-dists
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,18 +6,18 @@ on:
 jobs:
   commitlint:
     name: Commit Lint
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3.9.1
         with:
           node-version: 22
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,21 +6,21 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-dev:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.11", "3.12", "3.13" ]
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ uipath-ubuntu-latest, uipath-windows-latest ]
 
     permissions:
       contents: read

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: 'uipath-runtime-python'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
         run: uv build
 
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
@@ -56,7 +56,7 @@ jobs:
           uv run pytest
 
   typecheck-uipath-langchain:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
 
     permissions:
       contents: read
@@ -66,15 +66,15 @@ jobs:
 
     steps:
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: 'uipath-runtime-python'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -83,7 +83,7 @@ jobs:
         run: uv build
 
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
@@ -102,7 +102,7 @@ jobs:
           uv run mypy --config-file pyproject.toml .
 
   discover-testcases:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     needs: [test-uipath-langchain]
@@ -110,7 +110,7 @@ jobs:
       testcases: ${{ steps.discover.outputs.testcases }}
     steps:
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
@@ -130,7 +130,7 @@ jobs:
           echo "testcases=$testcases_json" >> $GITHUB_OUTPUT
 
   run-uipath-langchain-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     needs: [discover-testcases]
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: 'uipath-runtime-python'
 
@@ -159,7 +159,7 @@ jobs:
         run: uv build
 
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'

--- a/.github/workflows/test-uipath.yml
+++ b/.github/workflows/test-uipath.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.11", "3.12", "3.13" ]
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ uipath-ubuntu-latest, uipath-windows-latest ]
 
     permissions:
       contents: read

--- a/.github/workflows/test-uipath.yml
+++ b/.github/workflows/test-uipath.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: 'uipath-runtime-python'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
         run: uv build
 
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-python'
           path: 'uipath-python'
@@ -56,7 +56,7 @@ jobs:
           uv run pytest
 
   typecheck-uipath:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
 
     permissions:
       contents: read
@@ -66,15 +66,15 @@ jobs:
 
     steps:
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: 'uipath-runtime-python'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -83,7 +83,7 @@ jobs:
         run: uv build
 
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-python'
           path: 'uipath-python'
@@ -102,7 +102,7 @@ jobs:
           uv run mypy --config-file pyproject.toml .
 
   discover-testcases:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     needs: [test-uipath]
@@ -110,7 +110,7 @@ jobs:
       testcases: ${{ steps.discover.outputs.testcases }}
     steps:
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-python'
           path: 'uipath-python'
@@ -130,7 +130,7 @@ jobs:
           echo "testcases=$testcases_json" >> $GITHUB_OUTPUT
 
   run-uipath-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     needs: [discover-testcases]
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: 'uipath-runtime-python'
 
@@ -158,7 +158,7 @@ jobs:
         run: uv build
 
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-python'
           path: 'uipath-python'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,15 +34,15 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
-        if: "!(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')"
+        if: "!(matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13')"
         run: uv run pytest
 
       - name: Run tests with coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13'
         run: uv run pytest --cov-report=xml --cov-report=html --tb=short
 
       - name: Upload coverage HTML report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        if: matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13' && always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-report
@@ -50,7 +50,7 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage XML report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        if: matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13' && always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,20 +13,20 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
 
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload coverage HTML report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-report
           path: htmlcov/
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload coverage XML report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-report
           path: coverage.xml
@@ -62,23 +62,23 @@ jobs:
   sonarcloud:
     name: SonarCloud
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: always() && needs.test.result != 'failure'
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Download coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
           name: coverage-xml-report
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.