### PR TITLE
fix: continue execution when initial resume wait times out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.13.2"
+version = "0.13.3"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -120,6 +120,7 @@ class UiPathDebugRuntime:
         """Stream events from inner runtime and handle debug interactions."""
         final_result: UiPathRuntimeResult
         execution_completed = False
+        bridge_disconnected = False
 
         # Starting in paused state - wait for breakpoints and resume
         try:
@@ -129,11 +130,20 @@ class UiPathDebugRuntime:
             )
         except asyncio.TimeoutError:
             # Debug bridge likely disconnected: proceed unattended
-            # instead of failing the job.
+            # instead of failing the job. Drop the bridge entirely so a stale
+            # breakpoint set or a late command can never pause the run, and any
+            # further wait on debug commands would hang forever.
             logger.warning(
                 f"Initial resume wait timed out after {INITIAL_RESUME_TIMEOUT_SECONDS:g}s, "
-                "assuming debug bridge disconnected; continuing execution without debug commands"
+                "assuming debug bridge disconnected; disconnecting the bridge and "
+                "continuing execution unattended"
             )
+            bridge_disconnected = True
+            try:
+                await self.debug_bridge.disconnect()
+                logger.info("Debug bridge disconnected")
+            except Exception as e:
+                logger.warning(f"Error disconnecting debug bridge: {e}")
         except UiPathDebugQuitError:
             logger.info("Debug session quit by user before execution started")
             yield UiPathRuntimeResult(status=UiPathRuntimeStatus.SUCCESSFUL)
@@ -148,8 +158,11 @@ class UiPathDebugRuntime:
 
         # Keep streaming until execution completes (not just paused at breakpoint)
         while not execution_completed:
-            # Update breakpoints from debug bridge
-            debug_options.breakpoints = self.debug_bridge.get_breakpoints()
+            # Update breakpoints from debug bridge; with the bridge disconnected
+            # run without breakpoints so the delegate can never pause on them
+            debug_options.breakpoints = (
+                None if bridge_disconnected else self.debug_bridge.get_breakpoints()
+            )
 
             # Stream events from inner runtime
             async for event in self.delegate.stream(
@@ -183,8 +196,20 @@ class UiPathDebugRuntime:
                     else:
                         # Normal completion or suspension with dynamic interrupt
 
-                        # Check if this is a suspended execution that needs polling
                         if (
+                            bridge_disconnected
+                            and final_result.status == UiPathRuntimeStatus.SUSPENDED
+                        ):
+                            # Bridge is gone, so debug commands or inline polling
+                            # can never resume this run: end as suspended and let
+                            # the platform resume it via the real trigger
+                            logger.info(
+                                "Execution suspended with debug bridge disconnected, "
+                                "completing as suspended"
+                            )
+                            execution_completed = True
+                        # Check if this is a suspended execution that needs polling
+                        elif (
                             (resumable_runtime := self.get_resumable_runtime())
                             and self.trigger_poll_interval > 0
                             and final_result.status == UiPathRuntimeStatus.SUSPENDED

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -35,6 +35,8 @@ from uipath.runtime.schema import UiPathRuntimeSchema
 
 logger = logging.getLogger(__name__)
 
+INITIAL_RESUME_TIMEOUT_SECONDS = 60.0
+
 
 class UiPathDebugRuntime:
     """Specialized runtime for debug runs that streams events to a debug bridge."""
@@ -121,13 +123,16 @@ class UiPathDebugRuntime:
 
         # Starting in paused state - wait for breakpoints and resume
         try:
-            await asyncio.wait_for(self.debug_bridge.wait_for_resume(), timeout=60.0)
+            await asyncio.wait_for(
+                self.debug_bridge.wait_for_resume(),
+                timeout=INITIAL_RESUME_TIMEOUT_SECONDS,
+            )
         except asyncio.TimeoutError:
             # Debug bridge likely disconnected: proceed unattended
             # instead of failing the job.
             logger.warning(
-                "Initial resume wait timed out after 60s, assuming debug bridge "
-                "disconnected; continuing execution without debug commands"
+                f"Initial resume wait timed out after {INITIAL_RESUME_TIMEOUT_SECONDS:g}s, "
+                "assuming debug bridge disconnected; continuing execution without debug commands"
             )
         except UiPathDebugQuitError:
             logger.info("Debug session quit by user before execution started")

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -120,7 +120,6 @@ class UiPathDebugRuntime:
         """Stream events from inner runtime and handle debug interactions."""
         final_result: UiPathRuntimeResult
         execution_completed = False
-        bridge_disconnected = False
 
         # Starting in paused state - wait for breakpoints and resume
         try:
@@ -129,21 +128,32 @@ class UiPathDebugRuntime:
                 timeout=INITIAL_RESUME_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
-            # Debug bridge likely disconnected: proceed unattended
-            # instead of failing the job. Drop the bridge entirely so a stale
-            # breakpoint set or a late command can never pause the run, and any
-            # further wait on debug commands would hang forever.
+            # Debug bridge likely disconnected: proceed unattended instead of
+            # failing the job. Drop the bridge so a stale breakpoint set or a
+            # late command can never pause the run, then run the delegate in a
+            # single pass-through: no breakpoints, no inline resume handling,
+            # and a suspension is terminal (the platform resumes it via the
+            # real trigger).
             logger.warning(
                 f"Initial resume wait timed out after {INITIAL_RESUME_TIMEOUT_SECONDS:g}s, "
                 "assuming debug bridge disconnected; disconnecting the bridge and "
                 "continuing execution unattended"
             )
-            bridge_disconnected = True
             try:
                 await self.debug_bridge.disconnect()
                 logger.info("Debug bridge disconnected")
             except Exception as e:
                 logger.warning(f"Error disconnecting debug bridge: {e}")
+
+            async for event in self.delegate.stream(
+                input,
+                options=UiPathStreamOptions(
+                    resume=options.resume if options else False,
+                    breakpoints=None,
+                ),
+            ):
+                yield event
+            return
         except UiPathDebugQuitError:
             logger.info("Debug session quit by user before execution started")
             yield UiPathRuntimeResult(status=UiPathRuntimeStatus.SUCCESSFUL)
@@ -158,11 +168,8 @@ class UiPathDebugRuntime:
 
         # Keep streaming until execution completes (not just paused at breakpoint)
         while not execution_completed:
-            # Update breakpoints from debug bridge; with the bridge disconnected
-            # run without breakpoints so the delegate can never pause on them
-            debug_options.breakpoints = (
-                None if bridge_disconnected else self.debug_bridge.get_breakpoints()
-            )
+            # Update breakpoints from debug bridge
+            debug_options.breakpoints = self.debug_bridge.get_breakpoints()
 
             # Stream events from inner runtime
             async for event in self.delegate.stream(
@@ -196,20 +203,8 @@ class UiPathDebugRuntime:
                     else:
                         # Normal completion or suspension with dynamic interrupt
 
-                        if (
-                            bridge_disconnected
-                            and final_result.status == UiPathRuntimeStatus.SUSPENDED
-                        ):
-                            # Bridge is gone, so debug commands or inline polling
-                            # can never resume this run: end as suspended and let
-                            # the platform resume it via the real trigger
-                            logger.info(
-                                "Execution suspended with debug bridge disconnected, "
-                                "completing as suspended"
-                            )
-                            execution_completed = True
                         # Check if this is a suspended execution that needs polling
-                        elif (
+                        if (
                             (resumable_runtime := self.get_resumable_runtime())
                             and self.trigger_poll_interval > 0
                             and final_result.status == UiPathRuntimeStatus.SUSPENDED

--- a/src/uipath/runtime/debug/runtime.py
+++ b/src/uipath/runtime/debug/runtime.py
@@ -123,11 +123,12 @@ class UiPathDebugRuntime:
         try:
             await asyncio.wait_for(self.debug_bridge.wait_for_resume(), timeout=60.0)
         except asyncio.TimeoutError:
+            # Debug bridge likely disconnected: proceed unattended
+            # instead of failing the job.
             logger.warning(
-                "Initial resume wait timed out after 60s, assuming debug bridge disconnected"
+                "Initial resume wait timed out after 60s, assuming debug bridge "
+                "disconnected; continuing execution without debug commands"
             )
-            yield UiPathRuntimeResult(status=UiPathRuntimeStatus.FAULTED)
-            return
         except UiPathDebugQuitError:
             logger.info("Debug session quit by user before execution started")
             yield UiPathRuntimeResult(status=UiPathRuntimeStatus.SUCCESSFUL)

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -243,6 +243,28 @@ async def test_debug_runtime_continues_when_initial_resume_wait_times_out():
 
 
 @pytest.mark.asyncio
+async def test_debug_runtime_survives_disconnect_error_after_resume_wait_timeout():
+    """A failing bridge disconnect after the timeout must not fault the run."""
+
+    runtime_impl = StreamingMockRuntime(node_sequence=["node-1"])
+    bridge = make_debug_bridge_mock()
+    cast(AsyncMock, bridge.wait_for_resume).side_effect = asyncio.TimeoutError()
+    cast(AsyncMock, bridge.disconnect).side_effect = RuntimeError(
+        "socket already closed"
+    )
+
+    debug_runtime = UiPathDebugRuntime(
+        delegate=runtime_impl,
+        debug_bridge=bridge,
+    )
+
+    result = await debug_runtime.execute({})
+
+    assert result.status == UiPathRuntimeStatus.SUCCESSFUL
+    assert result.output == {"visited_nodes": ["node-1"]}
+
+
+@pytest.mark.asyncio
 async def test_debug_runtime_completes_as_suspended_after_resume_wait_timeout():
     """After the initial resume wait times out, a suspension must be terminal
     (the platform resumes via the real trigger) instead of waiting on debug

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -216,14 +216,16 @@ async def test_debug_runtime_streams_and_handles_breakpoints_and_state():
 @pytest.mark.asyncio
 async def test_debug_runtime_continues_when_initial_resume_wait_times_out():
     """If no resume command arrives before the initial wait times out,
-    execution should continue unattended instead of faulting."""
+    execution should disconnect the bridge and continue unattended
+    instead of faulting."""
 
     runtime_impl = StreamingMockRuntime(node_sequence=["node-1", "node-2"])
     bridge = make_debug_bridge_mock()
 
     # Initial resume wait times out (debug bridge disconnected)
     cast(AsyncMock, bridge.wait_for_resume).side_effect = asyncio.TimeoutError()
-    cast(Mock, bridge.get_breakpoints).return_value = []
+    # Stale breakpoints must not be honored once the bridge is dropped
+    cast(Mock, bridge.get_breakpoints).return_value = ["node-1", "node-2"]
 
     debug_runtime = UiPathDebugRuntime(
         delegate=runtime_impl,
@@ -234,7 +236,41 @@ async def test_debug_runtime_continues_when_initial_resume_wait_times_out():
 
     assert result.status == UiPathRuntimeStatus.SUCCESSFUL
     assert result.output == {"visited_nodes": ["node-1", "node-2"]}
+    cast(AsyncMock, bridge.disconnect).assert_awaited_once()
+    cast(Mock, bridge.get_breakpoints).assert_not_called()
+    cast(AsyncMock, bridge.emit_breakpoint_hit).assert_not_awaited()
     cast(AsyncMock, bridge.emit_execution_completed).assert_awaited_once_with(result)
+
+
+@pytest.mark.asyncio
+async def test_debug_runtime_completes_as_suspended_after_resume_wait_timeout():
+    """After the initial resume wait times out, a suspension must be terminal
+    (the platform resumes via the real trigger) instead of waiting on debug
+    commands from the disconnected bridge."""
+
+    trigger = UiPathResumeTrigger(
+        interrupt_id="api-interrupt",
+        trigger_type=UiPathResumeTriggerType.API,
+    )
+    runtime_impl = SuspendedThenSuccessfulRuntime(trigger)
+    bridge = make_debug_bridge_mock()
+    cast(AsyncMock, bridge.wait_for_resume).side_effect = asyncio.TimeoutError()
+
+    debug_runtime = UiPathDebugRuntime(
+        delegate=runtime_impl,
+        debug_bridge=bridge,
+    )
+    debug_runtime.get_resumable_runtime = Mock(  # type: ignore[method-assign]
+        return_value=Mock(trigger_manager=Mock())
+    )
+
+    result = await debug_runtime.execute({})
+
+    assert result.status == UiPathRuntimeStatus.SUSPENDED
+    assert result.trigger is trigger
+    # Only the initial wait; no resume wait for the suspension
+    assert cast(AsyncMock, bridge.wait_for_resume).await_count == 1
+    cast(AsyncMock, bridge.emit_execution_suspended).assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, AsyncGenerator, Sequence, cast
 from unittest.mock import AsyncMock, Mock
 
@@ -210,6 +211,30 @@ async def test_debug_runtime_streams_and_handles_breakpoints_and_state():
     assert (
         cast(AsyncMock, bridge.wait_for_resume).await_count == 2
     )  # initial + after breakpoint
+
+
+@pytest.mark.asyncio
+async def test_debug_runtime_continues_when_initial_resume_wait_times_out():
+    """If no resume command arrives before the initial wait times out,
+    execution should continue unattended instead of faulting."""
+
+    runtime_impl = StreamingMockRuntime(node_sequence=["node-1", "node-2"])
+    bridge = make_debug_bridge_mock()
+
+    # Initial resume wait times out (debug bridge disconnected)
+    cast(AsyncMock, bridge.wait_for_resume).side_effect = asyncio.TimeoutError()
+    cast(Mock, bridge.get_breakpoints).return_value = []
+
+    debug_runtime = UiPathDebugRuntime(
+        delegate=runtime_impl,
+        debug_bridge=bridge,
+    )
+
+    result = await debug_runtime.execute({})
+
+    assert result.status == UiPathRuntimeStatus.SUCCESSFUL
+    assert result.output == {"visited_nodes": ["node-1", "node-2"]}
+    cast(AsyncMock, bridge.emit_execution_completed).assert_awaited_once_with(result)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Problem

A debug run starts paused, waiting up to 60s for a resume command from the debug bridge. If the client disconnects and never sends one, the run ended `FAULTED` — intermittently failing resumed jobs whose debug client was no longer attached.

## Fix

On the initial resume-wait timeout, assume the bridge is disconnected and continue unattended instead of faulting: disconnect the bridge, then run the delegate in a single pass-through — no breakpoints, no inline resume handling. A suspension is terminal (the platform resumes it via the real trigger), avoiding unbounded waits on debug commands that can never arrive.

The explicit-quit path is unchanged.

## Testing

New tests cover: timeout → continue to success with stale breakpoints ignored, suspension after timeout ends `SUSPENDED`, and a failing bridge disconnect not faulting the run.

Manual validation for process tools and escalation scenarios.