### PR TITLE
fix: dispose the delegate from the conversational workspace runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.13.3"
+version = "0.13.4"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/runtime/workspace/conversational.py
+++ b/src/uipath/runtime/workspace/conversational.py
@@ -150,7 +150,8 @@ class ConversationalWorkspaceRuntime:
         return await self.delegate.get_schema()
 
     async def dispose(self) -> None:
-        """Release resources owned by this wrapper."""
+        """Dispose the delegate."""
+        await self.delegate.dispose()
 
     async def _hydrate(self, input: Mapping[str, object] | None) -> None:
         if self._hydrated:

--- a/tests/workspace/test_conversational_workspace.py
+++ b/tests/workspace/test_conversational_workspace.py
@@ -532,7 +532,9 @@ async def test_attachment_upload_failure_propagates(
 
 
 @pytest.mark.asyncio
-async def test_dispose_does_not_dispose_injected_dependencies(tmp_path: Path) -> None:
+async def test_dispose_disposes_delegate_but_not_injected_dependencies(
+    tmp_path: Path,
+) -> None:
     delegate = ScriptedRuntime(
         events=[],
         result=UiPathRuntimeResult(status=UiPathRuntimeStatus.SUCCESSFUL),
@@ -548,8 +550,7 @@ async def test_dispose_does_not_dispose_injected_dependencies(tmp_path: Path) ->
 
     await runtime.dispose()
 
-    assert not delegate.disposed
+    assert delegate.disposed
     assert workspace.path.exists()
 
-    await delegate.dispose()
     await workspace.dispose()

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary
- disposing a conversational workspace runtime now releases the runtimes it wraps, instead of leaving them open

## Why

Every other runtime wrapper in the stack disposes its delegate, so callers hold only the outermost wrapper and dispose that one to release the chain. `ConversationalWorkspaceRuntime` deliberately did not, on the grounds that a decorator does not own what it is handed. That is defensible in isolation, but it makes the outermost runtime the one whose `dispose` does nothing, and the wrappers below it (resumable, hydration, and the host's own layers) plus their temporary workspaces stay alive until the process exits.

Consumers currently work around it by keeping a side list of the runtimes they still own and disposing those by hand, which is easy to forget and invisible when reading the wrapping code.

Injected dependencies keep the previous behavior: the hydrator, the registry store, and the workspace are not disposed here.