### PR TITLE
docs: correct Args section in UiPathExecutionRuntime.stream docstring

### DIFF
--- a/src/uipath/runtime/base.py
+++ b/src/uipath/runtime/base.py
@@ -195,8 +195,8 @@ class UiPathExecutionRuntime:
         """Stream runtime execution with context.
 
         Args:
-            runtime: The runtime instance
-            context: The runtime context
+            input: The input data for the runtime
+            options: Streaming-specific execution options
 
         Yields:
             UiPathRuntimeEvent instances during execution and final UiPathRuntimeResult


### PR DESCRIPTION
## Summary

Fix 1 copy-paste error in a docstring:

- **src/uipath/runtime/base.py**: the `Args:` section of `UiPathExecutionRuntime.stream()` documented `runtime` and `context`, neither of which is a parameter of the method. The actual signature is `stream(self, input: dict[str, Any] | None = None, options: UiPathStreamOptions | None = None)`, so the section now documents `input` and `options`.

The `options` description mirrors the `UiPathStreamOptions` class docstring ("Streaming-specific execution options").

No functional changes - docstring only. No identifiers were renamed.