### PR TITLE
feat: stream job logs to the handler over uipath-ipc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-runtime"
-version = "0.13.4"
+version = "0.13.5"
 description = "Runtime abstractions and interfaces for building agents and automation scripts in the UiPath ecosystem"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -19,6 +19,10 @@ classifiers = [
 maintainers = [
   { name = "Cristian Pufu", email = "cristian.pufu@uipath.com" },
 ]
+
+[project.optional-dependencies]
+# Job-API IPC log channel; required when UIPATH_JOB_API_IPC_ENDPOINT is set.
+ipc = ["uipath-ipc>=2.5.1, <2.6.0"]
 
 [project.urls]
 Homepage = "https://uipath.com"
@@ -42,6 +46,7 @@ dev = [
   "pytest-cov>=4.1.0",
   "pytest-mock>=3.11.1",
   "pre-commit>=4.1.0",
+  "uipath-ipc>=2.5.1, <2.6.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -123,6 +128,7 @@ exclude-newer = "2 days"
 
 [tool.uv.exclude-newer-package]
 uipath-core = false
+uipath-ipc = false
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/src/uipath/runtime/context.py
+++ b/src/uipath/runtime/context.py
@@ -18,6 +18,9 @@ from uipath.runtime.errors import (
     UiPathErrorContract,
     UiPathRuntimeError,
 )
+from uipath.runtime.jobapi.client import IpcJobApiClient
+from uipath.runtime.jobapi.log_handler import IpcSendLogHandler, PooledIpcSendLogHandler
+from uipath.runtime.jobapi.pooled import get_pooled_log_sink
 from uipath.runtime.logging._interceptor import UiPathRuntimeLogsInterceptor
 from uipath.runtime.result import UiPathRuntimeResult, UiPathRuntimeStatus
 
@@ -120,8 +123,37 @@ class UiPathRuntimeContext(BaseModel):
     keep_state_file: bool = Field(
         False, description="Prevents deletion of state file before running."
     )
+    ipc_endpoint: str | None = Field(
+        None,
+        description=(
+            "uipath-ipc endpoint (UIPATH_JOB_API_IPC_ENDPOINT) for streaming logs to "
+            "the handler in place of execution.log. The result stays on output.json."
+        ),
+    )
+    ipc_job_id: str | None = Field(
+        None,
+        description="Handler job id (UIPATH_JOB_ID) used to route the IPC calls.",
+    )
+    ipc_client: Any = Field(default=None, exclude=True, repr=False)
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+
+    @property
+    def ipc_active(self) -> bool:
+        """Whether logs flow over a per-job IPC pipe (non-pooled) instead of to files."""
+        return bool(self.ipc_endpoint and self.ipc_job_id)
+
+    @property
+    def pooled_ipc_active(self) -> bool:
+        """Whether logs stream over the pooled server's callback rather than a per-job pipe.
+
+        True when there is a job id but no endpoint, and the pooled server registered its sink.
+        """
+        return (
+            bool(self.ipc_job_id)
+            and not self.ipc_endpoint
+            and get_pooled_log_sink() is not None
+        )
 
     def _apply_execution_source(self) -> None:
         """Derive execution_source from the command, if not already set.
@@ -240,11 +272,27 @@ class UiPathRuntimeContext(BaseModel):
         """
         # Intercept all stdout/stderr/logs
         # Write to file (runtime), stdout (debug) or log handler (if provided)
+        log_handler: logging.Handler | None = None
+        if self.ipc_active:
+            assert self.ipc_endpoint is not None and self.ipc_job_id is not None
+            self.ipc_client = IpcJobApiClient(
+                self.ipc_endpoint, self.ipc_job_id, logger
+            )
+            self.ipc_client.start()
+            log_handler = IpcSendLogHandler(self.ipc_client)
+            log_handler.setFormatter(logging.Formatter("%(message)s"))
+        elif self.pooled_ipc_active:
+            sink = get_pooled_log_sink()
+            assert self.ipc_job_id is not None and sink is not None
+            log_handler = PooledIpcSendLogHandler(self.ipc_job_id, sink)
+            log_handler.setFormatter(logging.Formatter("%(message)s"))
+
         self.logs_interceptor = UiPathRuntimeLogsInterceptor(
             min_level=self.logs_min_level,
             dir=self.runtime_dir,
             file=self.logs_file,
             job_id=self.job_id,
+            log_handler=log_handler,
         )
         self.logs_interceptor.setup()
 
@@ -354,6 +402,8 @@ class UiPathRuntimeContext(BaseModel):
             # Restore original logging
             if hasattr(self, "logs_interceptor"):
                 self.logs_interceptor.teardown()
+            if self.ipc_client is not None:
+                self.ipc_client.close()
 
     @cached_property
     def resolved_result_file_path(self) -> str:
@@ -418,6 +468,8 @@ class UiPathRuntimeContext(BaseModel):
         base.tenant_id = os.environ.get("UIPATH_TENANT_ID")
         base.process_key = os.environ.get("UIPATH_PROCESS_UUID")
         base.folder_key = os.environ.get("UIPATH_FOLDER_KEY")
+        base.ipc_endpoint = os.environ.get("UIPATH_JOB_API_IPC_ENDPOINT")
+        base.ipc_job_id = os.environ.get("UIPATH_JOB_ID")
 
         # Override with kwargs
         for k, v in kwargs.items():

--- a/src/uipath/runtime/jobapi/__init__.py
+++ b/src/uipath/runtime/jobapi/__init__.py
@@ -1,0 +1,29 @@
+"""Job-API IPC: stream job logs back to the handler (per-job client or pooled callback)."""
+
+from uipath.runtime.jobapi.client import IpcJobApiClient
+from uipath.runtime.jobapi.contract import (
+    IIpcLogSink,
+    JobLogDto,
+    LogLevel,
+)
+from uipath.runtime.jobapi.log_handler import (
+    IpcSendLogHandler,
+    PooledIpcSendLogHandler,
+)
+from uipath.runtime.jobapi.pooled import (
+    PooledLogSink,
+    get_pooled_log_sink,
+    set_pooled_log_sink,
+)
+
+__all__ = [
+    "IIpcLogSink",
+    "IpcJobApiClient",
+    "IpcSendLogHandler",
+    "JobLogDto",
+    "LogLevel",
+    "PooledIpcSendLogHandler",
+    "PooledLogSink",
+    "get_pooled_log_sink",
+    "set_pooled_log_sink",
+]

--- a/src/uipath/runtime/jobapi/client.py
+++ b/src/uipath/runtime/jobapi/client.py
@@ -1,0 +1,184 @@
+"""uipath-ipc client that streams job logs to the handler (logs only)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import threading
+import time
+from typing import Any
+
+from uipath.runtime.jobapi.contract import IIpcLogSink, JobLogDto
+
+_SEND_TIMEOUT_S = 1.0
+_MAX_SEND_ATTEMPTS = 3
+_RETRY_DELAY_S = 0.2
+_MAX_CONSECUTIVE_DROPS = 3
+_FAILURE_COOLDOWN_S = 30.0
+_STARTUP_TIMEOUT_S = 10.0
+_SHUTDOWN_TIMEOUT_S = 15.0
+
+_STOP = object()
+
+
+class IpcJobApiClient:
+    """Owns a uipath-ipc client on a private event-loop thread.
+
+    The runtime's ``__exit__`` is synchronous but IPC is asyncio-based, so the
+    client runs its loop on its own thread (a Proactor loop on Windows, which
+    named pipes require). Logs are enqueued without blocking the caller and
+    drained one at a time, FIFO; the queue is flushed at job end. A send that
+    fails is retried a few times, then that one entry is dropped, and after
+    repeated failures forwarding is muted for a cooldown — mirroring the JS
+    coded-functions log forwarder.
+    """
+
+    def __init__(self, endpoint: str, job_id: str, log: logging.Logger) -> None:
+        """Configure the client; call ``start()`` to connect."""
+        self._endpoint = endpoint
+        self._job_id = job_id
+        self._log = log
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._queue: asyncio.Queue[Any] | None = None
+        self._proxy: IIpcLogSink | None = None
+        self._client: Any = None
+        self._consumer: asyncio.Task[None] | None = None
+        self._ready = threading.Event()
+        self._start_error: BaseException | None = None
+        self._stopping = False
+
+    def start(self) -> None:
+        """Start the loop thread and connect; raise if that fails or times out."""
+        if importlib.util.find_spec("uipath_ipc") is None:
+            raise RuntimeError(
+                "Job-API IPC was requested (UIPATH_JOB_API_IPC_ENDPOINT is set) but "
+                "the 'uipath-ipc' package is not installed. Install it (e.g. "
+                "'pip install uipath-ipc') to stream logs over IPC."
+            )
+
+        self._thread = threading.Thread(
+            target=self._run, name="uipath-jobapi-ipc", daemon=True
+        )
+        self._thread.start()
+        if not self._ready.wait(timeout=_STARTUP_TIMEOUT_S):
+            raise RuntimeError(
+                f"Job-API IPC client did not connect within {_STARTUP_TIMEOUT_S}s "
+                f"(endpoint {self._endpoint!r})."
+            )
+        if self._start_error is not None:
+            raise self._start_error
+
+    def _run(self) -> None:
+        try:
+            if sys.platform == "win32":
+                self._loop = asyncio.ProactorEventLoop()
+            else:
+                self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+            self._loop.run_until_complete(self._setup())
+        except BaseException as e:
+            self._start_error = e
+            self._ready.set()
+            return
+        self._ready.set()
+        try:
+            self._loop.run_forever()
+        finally:
+            self._loop.close()
+
+    async def _setup(self) -> None:
+        from uipath_ipc import IpcClient, NamedPipeClientTransport
+
+        self._client = IpcClient(
+            transport=NamedPipeClientTransport(self._endpoint),
+            request_timeout=None,
+        )
+        self._proxy = self._client.get_proxy(IIpcLogSink)
+        self._queue = asyncio.Queue()
+        self._consumer = asyncio.ensure_future(self._consume())
+
+    async def _consume(self) -> None:
+        assert self._queue is not None
+        consecutive_drops = 0
+        muted_until = 0.0
+        while True:
+            item = await self._queue.get()
+            try:
+                if item is _STOP:
+                    return
+                if time.monotonic() < muted_until:
+                    continue
+                if await self._send_log_once(item):
+                    consecutive_drops = 0
+                else:
+                    consecutive_drops += 1
+                    if consecutive_drops >= _MAX_CONSECUTIVE_DROPS:
+                        muted_until = time.monotonic() + _FAILURE_COOLDOWN_S
+                        consecutive_drops = 0
+                        self._log.warning(
+                            "Job-API IPC: log forwarding paused for %ss after "
+                            "repeated send failures.",
+                            int(_FAILURE_COOLDOWN_S),
+                        )
+            finally:
+                self._queue.task_done()
+
+    async def _send_log_once(self, dto: JobLogDto) -> bool:
+        assert self._proxy is not None
+        last_err: BaseException | None = None
+        for attempt in range(1, _MAX_SEND_ATTEMPTS + 1):
+            try:
+                await asyncio.wait_for(
+                    self._proxy.SendLog(self._job_id, dto), timeout=_SEND_TIMEOUT_S
+                )
+                return True
+            except Exception as e:
+                last_err = e
+                if attempt < _MAX_SEND_ATTEMPTS:
+                    await asyncio.sleep(_RETRY_DELAY_S)
+        self._log.debug("Job-API IPC: dropped one log entry: %s", last_err)
+        return False
+
+    def send_log(self, dto: JobLogDto) -> None:
+        """Enqueue one log entry for sending (thread-safe, never blocks)."""
+        loop = self._loop
+        queue = self._queue
+        if loop is None or queue is None or self._stopping:
+            return
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, dto)
+        except RuntimeError:
+            pass
+
+    def close(self) -> None:
+        """Flush queued logs, close the client, and join the loop thread."""
+        self._stopping = True
+        loop = self._loop
+        thread = self._thread
+        if loop is None or thread is None or not thread.is_alive():
+            return
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self._shutdown(), loop)
+            fut.result(timeout=_SHUTDOWN_TIMEOUT_S)
+        except Exception as e:
+            self._log.debug("Job-API IPC: error during shutdown: %s", e)
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=_SHUTDOWN_TIMEOUT_S)
+
+    async def _shutdown(self) -> None:
+        if self._queue is not None and self._consumer is not None:
+            await self._queue.join()
+            self._queue.put_nowait(_STOP)
+            try:
+                await asyncio.wait_for(self._consumer, timeout=_SHUTDOWN_TIMEOUT_S)
+            except Exception:
+                self._consumer.cancel()
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception as e:
+                self._log.debug("Job-API IPC: error closing client: %s", e)

--- a/src/uipath/runtime/jobapi/contract.py
+++ b/src/uipath/runtime/jobapi/contract.py
@@ -1,0 +1,39 @@
+"""Python mirror of the .NET ``IIpcLogSink`` CoreIpc contract (logs only).
+
+uipath-ipc routes by the contract class ``__name__`` and method name and serializes each
+argument by its declared field names, so the class name, the method name, and every field
+below must match the .NET side exactly. The result is not sent over IPC — it stays on
+``output.json``, which the handler still reads.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class LogLevel(IntEnum):
+    """Mirror of Microsoft.Extensions.Logging.LogLevel (the wire values)."""
+
+    TRACE = 0
+    DEBUG = 1
+    INFORMATION = 2
+    WARNING = 3
+    ERROR = 4
+    CRITICAL = 5
+    NONE = 6
+
+
+@dataclass
+class JobLogDto:
+    """A single log entry (PascalCase fields to match the wire)."""
+
+    Message: str = ""
+    LogLevel: int = LogLevel.INFORMATION.value
+
+
+class IIpcLogSink(ABC):
+    """The handler's log-sink contract; the class name is the CoreIpc endpoint key."""
+
+    @abstractmethod
+    async def SendLog(self, jobId: str, log: JobLogDto) -> None:
+        """Forward one log entry (one-way)."""

--- a/src/uipath/runtime/jobapi/log_handler.py
+++ b/src/uipath/runtime/jobapi/log_handler.py
@@ -1,0 +1,61 @@
+"""Logging handlers that forward records to the handler over uipath-ipc."""
+
+import logging
+
+from uipath.runtime.jobapi.client import IpcJobApiClient
+from uipath.runtime.jobapi.contract import JobLogDto, LogLevel
+from uipath.runtime.jobapi.pooled import PooledLogSink
+
+
+def _to_log_level(levelno: int) -> int:
+    if levelno >= logging.CRITICAL:
+        return LogLevel.CRITICAL
+    if levelno >= logging.ERROR:
+        return LogLevel.ERROR
+    if levelno >= logging.WARNING:
+        return LogLevel.WARNING
+    if levelno >= logging.INFO:
+        return LogLevel.INFORMATION
+    if levelno >= logging.DEBUG:
+        return LogLevel.DEBUG
+    return LogLevel.TRACE
+
+
+class IpcSendLogHandler(logging.Handler):
+    """Forwards each record to the handler's IIpcLogSink via the non-pooled per-job client."""
+
+    def __init__(self, client: IpcJobApiClient) -> None:
+        """Wrap the IPC client the records are forwarded through."""
+        super().__init__()
+        self._client = client
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Format the record and hand it to the IPC client (non-blocking)."""
+        try:
+            message = self.format(record)
+            self._client.send_log(
+                JobLogDto(Message=message, LogLevel=_to_log_level(record.levelno))
+            )
+        except Exception:
+            self.handleError(record)
+
+
+class PooledIpcSendLogHandler(logging.Handler):
+    """Forwards each record to the pooled process-global sink, tagged with the job id."""
+
+    def __init__(self, job_id: str, sink: PooledLogSink) -> None:
+        """Bind the job id every record is tagged with and the sink to forward through."""
+        super().__init__()
+        self._job_id = job_id
+        self._sink = sink
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Format the record and hand it to the pooled sink (non-blocking)."""
+        try:
+            message = self.format(record)
+            self._sink(
+                self._job_id,
+                JobLogDto(Message=message, LogLevel=_to_log_level(record.levelno)),
+            )
+        except Exception:
+            self.handleError(record)

--- a/src/uipath/runtime/jobapi/pooled.py
+++ b/src/uipath/runtime/jobapi/pooled.py
@@ -1,0 +1,28 @@
+"""Process-global log sink for the pooled path.
+
+In pooled mode the job runs in-process inside ``uipath server``, which owns the CoreIpc
+callback to the handler. The runtime can't reach that callback directly, so the pooled
+server registers a sink here and the runtime's log handler forwards to it. The sink is
+called from the job's logging (a worker thread), so it must be non-blocking and thread-safe.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from uipath.runtime.jobapi.contract import JobLogDto
+
+PooledLogSink = Callable[[str, JobLogDto], None]
+
+_sink: "PooledLogSink | None" = None
+
+
+def set_pooled_log_sink(sink: "PooledLogSink | None") -> None:
+    """Register (or clear, with ``None``) the process-global pooled log sink."""
+    global _sink
+    _sink = sink
+
+
+def get_pooled_log_sink() -> "PooledLogSink | None":
+    """The registered pooled log sink, or None when not in a pooled server."""
+    return _sink

--- a/tests/test_context_ipc.py
+++ b/tests/test_context_ipc.py
@@ -1,0 +1,163 @@
+"""Context wiring for the job-API IPC channel (logs only).
+
+The real IpcJobApiClient (threads + named pipes) is replaced by a recording fake
+so these tests exercise the context's branching, not the transport — the
+transport itself is covered by test_jobapi_client.py. The result stays on
+output.json; only the logs move to IPC (and execution.log is suppressed).
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from uipath.runtime.context import UiPathRuntimeContext
+from uipath.runtime.jobapi.log_handler import IpcSendLogHandler, PooledIpcSendLogHandler
+from uipath.runtime.jobapi.pooled import set_pooled_log_sink
+from uipath.runtime.result import UiPathRuntimeResult, UiPathRuntimeStatus
+
+
+class _FakeIpcClient:
+    def __init__(self, endpoint: str, job_id: str, log: Any) -> None:
+        self.endpoint = endpoint
+        self.job_id = job_id
+        self.started = False
+        self.closed = False
+        self.logs: list[Any] = []
+
+    def start(self) -> None:
+        self.started = True
+
+    def send_log(self, dto: Any) -> None:
+        self.logs.append(dto)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _DummyInterceptor:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.log_handler = kwargs.get("log_handler")
+
+    def setup(self) -> None:
+        pass
+
+    def teardown(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("uipath.runtime.context.IpcJobApiClient", _FakeIpcClient)
+    monkeypatch.setattr(
+        "uipath.runtime.context.UiPathRuntimeLogsInterceptor", _DummyInterceptor
+    )
+
+
+def _ipc_ctx(tmp_path: Path, **kwargs: Any) -> UiPathRuntimeContext:
+    return UiPathRuntimeContext(
+        job_id="job-key",
+        runtime_dir=str(tmp_path / "rt"),
+        result_file="output.json",
+        ipc_endpoint="the-pipe",
+        ipc_job_id="job-guid",
+        **kwargs,
+    )
+
+
+def test_with_defaults_reads_ipc_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("UIPATH_JOB_API_IPC_ENDPOINT", "ep")
+    monkeypatch.setenv("UIPATH_JOB_ID", "jid")
+
+    ctx = UiPathRuntimeContext.with_defaults()
+
+    assert ctx.ipc_endpoint == "ep"
+    assert ctx.ipc_job_id == "jid"
+    assert ctx.ipc_active is True
+
+
+def test_ipc_inactive_without_both_env_vars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("UIPATH_JOB_API_IPC_ENDPOINT", "ep")
+    monkeypatch.delenv("UIPATH_JOB_ID", raising=False)
+
+    ctx = UiPathRuntimeContext.with_defaults()
+
+    assert ctx.ipc_active is False
+
+
+def test_enter_starts_client_and_injects_ipc_log_handler(tmp_path: Path) -> None:
+    ctx = _ipc_ctx(tmp_path)
+    with ctx:
+        pass
+
+    client = ctx.ipc_client
+    assert client.started is True
+    assert client.endpoint == "the-pipe"
+    assert client.job_id == "job-guid"
+    # The interceptor was handed our IPC handler (so no execution.log is opened).
+    assert isinstance(ctx.logs_interceptor.log_handler, IpcSendLogHandler)
+
+
+def test_result_still_written_to_file_when_ipc_active(tmp_path: Path) -> None:
+    ctx = _ipc_ctx(tmp_path)
+    with ctx:
+        ctx.result = UiPathRuntimeResult(
+            status=UiPathRuntimeStatus.SUCCESSFUL, output={"foo": "bar"}
+        )
+
+    # Only the logs move to IPC; the result stays on output.json for the handler.
+    content = json.loads(Path(ctx.resolved_result_file_path).read_text())
+    assert content["output"] == {"foo": "bar"}
+    assert ctx.ipc_client.closed is True
+
+
+def test_pooled_ipc_injects_pooled_handler_result_stays_on_file(tmp_path: Path) -> None:
+    # Pooled: a job id but no endpoint, plus a registered process-global sink.
+    calls: list[Any] = []
+    set_pooled_log_sink(lambda job_id, log: calls.append((job_id, log)))
+    try:
+        ctx = UiPathRuntimeContext(
+            job_id="job-key",
+            runtime_dir=str(tmp_path / "rt"),
+            result_file="output.json",
+            ipc_job_id="job-guid",  # no ipc_endpoint -> pooled path
+        )
+        assert ctx.pooled_ipc_active is True
+
+        with ctx:
+            ctx.result = UiPathRuntimeResult(
+                status=UiPathRuntimeStatus.SUCCESSFUL, output={"foo": "bar"}
+            )
+
+        # The interceptor got the pooled handler (so execution.log is suppressed), and no per-job
+        # client was created (pooled forwards through the process-global sink instead).
+        assert isinstance(ctx.logs_interceptor.log_handler, PooledIpcSendLogHandler)
+        assert ctx.ipc_client is None
+        # The result still lands on output.json (logs-only channel).
+        content = json.loads(Path(ctx.resolved_result_file_path).read_text())
+        assert content["output"] == {"foo": "bar"}
+    finally:
+        set_pooled_log_sink(None)
+
+
+def test_no_ipc_log_handler_when_inactive(tmp_path: Path) -> None:
+    ctx = UiPathRuntimeContext(
+        job_id="job-key",
+        runtime_dir=str(tmp_path / "rt"),
+        result_file="output.json",
+    )
+    with ctx:
+        ctx.result = UiPathRuntimeResult(
+            status=UiPathRuntimeStatus.SUCCESSFUL, output={"foo": "bar"}
+        )
+
+    # No IPC → the interceptor builds its own (file) handler and no client is made.
+    assert ctx.logs_interceptor.log_handler is None
+    assert ctx.ipc_client is None

--- a/tests/test_jobapi_client.py
+++ b/tests/test_jobapi_client.py
@@ -1,0 +1,152 @@
+import asyncio
+import logging
+import time
+import uuid
+
+import pytest
+
+import uipath.runtime.jobapi.client as client_mod
+from uipath.runtime.jobapi.client import IpcJobApiClient
+from uipath.runtime.jobapi.contract import IIpcLogSink, JobLogDto
+
+
+def test_start_without_uipath_ipc_raises_loudly(monkeypatch):
+    # A missing transport must fail, not silently skip: the handler has already
+    # stopped reading the execution.log this client replaces.
+    monkeypatch.setattr(
+        "uipath.runtime.jobapi.client.importlib.util.find_spec",
+        lambda name: None,
+    )
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+    with pytest.raises(RuntimeError, match="uipath-ipc"):
+        client.start()
+
+
+async def test_roundtrip_streams_logs_and_flushes_on_close():
+    pytest.importorskip("uipath_ipc")
+    from uipath_ipc import IpcServer, NamedPipeServerTransport
+
+    pipe = f"uipath-jobapi-test-{uuid.uuid4().hex}"
+    received: list[tuple[object, object]] = []
+
+    class _FakeHandler(IIpcLogSink):
+        async def SendLog(self, jobId, log):
+            received.append((jobId, log))
+
+    server = IpcServer(
+        transport=NamedPipeServerTransport(pipe),
+        services={IIpcLogSink: _FakeHandler()},
+        request_timeout=None,
+    )
+    async with server:
+        serve = asyncio.ensure_future(server.serve_forever())
+        try:
+            job_id = str(uuid.uuid4())
+            client = IpcJobApiClient(pipe, job_id, logging.getLogger("test"))
+            await asyncio.to_thread(client.start)
+            client.send_log(JobLogDto(Message="first", LogLevel=2))
+            client.send_log(JobLogDto(Message="second", LogLevel=3))
+            # close() flushes the queue before tearing the channel down.
+            await asyncio.to_thread(client.close)
+        finally:
+            serve.cancel()
+
+    def _field(obj, name):
+        return getattr(obj, name) if hasattr(obj, name) else obj[name]
+
+    assert [
+        (_field(log, "Message"), _field(log, "LogLevel")) for _, log in received
+    ] == [
+        ("first", 2),
+        ("second", 3),
+    ]
+    assert all(job == job_id for job, _ in received)
+
+
+def test_start_times_out_when_thread_never_ready(monkeypatch):
+    monkeypatch.setattr(
+        "uipath.runtime.jobapi.client.importlib.util.find_spec",
+        lambda name: object(),
+    )
+    monkeypatch.setattr(client_mod, "_STARTUP_TIMEOUT_S", 0.1)
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+    monkeypatch.setattr(client, "_run", lambda: time.sleep(2))
+    with pytest.raises(RuntimeError, match="did not connect"):
+        client.start()
+
+
+def test_start_raises_when_setup_fails(monkeypatch):
+    monkeypatch.setattr(
+        "uipath.runtime.jobapi.client.importlib.util.find_spec",
+        lambda name: object(),
+    )
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+
+    async def _boom():
+        raise RuntimeError("setup boom")
+
+    monkeypatch.setattr(client, "_setup", _boom)
+    with pytest.raises(RuntimeError, match="setup boom"):
+        client.start()
+
+
+async def test_send_log_once_retries_then_drops(monkeypatch):
+    monkeypatch.setattr(client_mod, "_RETRY_DELAY_S", 0)
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+
+    class _Boom(IIpcLogSink):
+        async def SendLog(self, jobId, log):
+            raise RuntimeError("nope")
+
+    client._proxy = _Boom()
+    assert await client._send_log_once(JobLogDto(Message="m")) is False
+
+
+async def test_consume_mutes_after_repeated_failures(monkeypatch):
+    monkeypatch.setattr(client_mod, "_RETRY_DELAY_S", 0)
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+    sends = 0
+
+    class _Boom(IIpcLogSink):
+        async def SendLog(self, jobId, log):
+            nonlocal sends
+            sends += 1
+            raise RuntimeError("x")
+
+    client._proxy = _Boom()
+    client._queue = asyncio.Queue()
+    task = asyncio.ensure_future(client._consume())
+
+    for i in range(client_mod._MAX_CONSECUTIVE_DROPS):
+        client._queue.put_nowait(JobLogDto(Message=str(i)))
+    await client._queue.join()
+    sends_while_trying = sends
+
+    client._queue.put_nowait(JobLogDto(Message="muted"))
+    await client._queue.join()
+    assert sends == sends_while_trying  # dropped while muted, no send attempted
+
+    client._queue.put_nowait(client_mod._STOP)
+    await task
+
+
+def test_send_log_noop_before_start():
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+    client.send_log(JobLogDto(Message="x"))
+
+
+async def test_send_log_swallows_closed_loop_error():
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+
+    class _DeadLoop:
+        def call_soon_threadsafe(self, *args):
+            raise RuntimeError("loop closed")
+
+    client._loop = _DeadLoop()  # type: ignore[assignment]
+    client._queue = asyncio.Queue()
+    client.send_log(JobLogDto(Message="x"))
+
+
+def test_close_noop_before_start():
+    client = IpcJobApiClient("pipe", "job", logging.getLogger("test"))
+    client.close()

--- a/tests/test_jobapi_contract.py
+++ b/tests/test_jobapi_contract.py
@@ -1,0 +1,41 @@
+import pytest
+
+from uipath.runtime.jobapi.contract import (
+    IIpcLogSink,
+    JobLogDto,
+    LogLevel,
+)
+
+
+def test_endpoint_name_matches_dotnet_router_key():
+    # uipath-ipc routes by the contract class __name__, which must equal the
+    # .NET interface name the Python executors register (IIpcLogSink, the log
+    # channel that .NET's IJobInvocationApi extends).
+    assert IIpcLogSink.__name__ == "IIpcLogSink"
+
+
+def test_contract_only_declares_send_log():
+    # Scope is logs only; the result stays on output.json.
+    assert hasattr(IIpcLogSink, "SendLog")
+    assert not hasattr(IIpcLogSink, "SetResult")
+
+
+def test_log_level_values_match_microsoft_extensions():
+    assert [
+        LogLevel.TRACE,
+        LogLevel.DEBUG,
+        LogLevel.INFORMATION,
+        LogLevel.WARNING,
+        LogLevel.ERROR,
+        LogLevel.CRITICAL,
+        LogLevel.NONE,
+    ] == [0, 1, 2, 3, 4, 5, 6]
+
+
+def test_job_log_dto_wire_shape():
+    # The field names are the wire keys, so this pins them against the .NET DTO.
+    to_wire = pytest.importorskip("uipath_ipc").to_wire
+    assert to_wire(JobLogDto(Message="hi", LogLevel=3)) == {
+        "Message": "hi",
+        "LogLevel": 3,
+    }

--- a/tests/test_jobapi_log_handler.py
+++ b/tests/test_jobapi_log_handler.py
@@ -1,0 +1,57 @@
+import logging
+
+from uipath.runtime.jobapi.contract import JobLogDto, LogLevel
+from uipath.runtime.jobapi.log_handler import IpcSendLogHandler, _to_log_level
+
+
+def test_to_log_level_mapping():
+    assert _to_log_level(logging.CRITICAL) == LogLevel.CRITICAL
+    assert _to_log_level(logging.ERROR) == LogLevel.ERROR
+    assert _to_log_level(logging.WARNING) == LogLevel.WARNING
+    assert _to_log_level(logging.INFO) == LogLevel.INFORMATION
+    assert _to_log_level(logging.DEBUG) == LogLevel.DEBUG
+    # Below DEBUG collapses to TRACE; above CRITICAL clamps to CRITICAL.
+    assert _to_log_level(1) == LogLevel.TRACE
+    assert _to_log_level(logging.CRITICAL + 10) == LogLevel.CRITICAL
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.logs: list[JobLogDto] = []
+
+    def send_log(self, dto: JobLogDto) -> None:
+        self.logs.append(dto)
+
+
+def test_emit_forwards_formatted_message_and_level():
+    client = _RecordingClient()
+    handler = IpcSendLogHandler(client)  # type: ignore[arg-type]
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    record = logging.LogRecord(
+        name="n",
+        level=logging.WARNING,
+        pathname="p",
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    handler.emit(record)
+
+    assert len(client.logs) == 1
+    assert client.logs[0].Message == "hello world"
+    assert client.logs[0].LogLevel == LogLevel.WARNING
+
+
+def test_emit_swallows_client_errors():
+    class _Boom:
+        def send_log(self, dto: JobLogDto) -> None:
+            raise RuntimeError("pipe down")
+
+    handler = IpcSendLogHandler(_Boom())  # type: ignore[arg-type]
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord("n", logging.INFO, "p", 1, "x", None, None)
+
+    # handleError writes to sys.stderr but must not raise.
+    handler.emit(record)

--- a/tests/test_jobapi_pooled.py
+++ b/tests/test_jobapi_pooled.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Any
+
+import pytest
+
+from uipath.runtime.jobapi.contract import JobLogDto, LogLevel
+from uipath.runtime.jobapi.log_handler import PooledIpcSendLogHandler
+from uipath.runtime.jobapi.pooled import get_pooled_log_sink, set_pooled_log_sink
+
+
+@pytest.fixture(autouse=True)
+def _clear_sink():
+    # The sink is process-global; make sure a test never leaks it to the next.
+    set_pooled_log_sink(None)
+    yield
+    set_pooled_log_sink(None)
+
+
+def test_sink_registry_set_and_clear():
+    assert get_pooled_log_sink() is None
+
+    def sink(job_id: str, log: JobLogDto) -> None:
+        pass
+
+    set_pooled_log_sink(sink)
+    assert get_pooled_log_sink() is sink
+
+    set_pooled_log_sink(None)
+    assert get_pooled_log_sink() is None
+
+
+def test_pooled_handler_forwards_tagged_with_job_id():
+    calls: list[tuple[str, Any]] = []
+    handler = PooledIpcSendLogHandler(
+        "job-key-1", lambda jid, log: calls.append((jid, log))
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    record = logging.LogRecord(
+        name="n",
+        level=logging.WARNING,
+        pathname="p",
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    handler.emit(record)
+
+    assert len(calls) == 1
+    job_id, log = calls[0]
+    assert job_id == "job-key-1"
+    assert log.Message == "hello world"
+    assert log.LogLevel == LogLevel.WARNING
+
+
+def test_pooled_handler_swallows_sink_errors():
+    def boom(job_id: str, log: JobLogDto) -> None:
+        raise RuntimeError("pipe down")
+
+    handler = PooledIpcSendLogHandler("job-key-1", boom)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord("n", logging.INFO, "p", 1, "x", None, None)
+
+    # handleError writes to stderr but must not raise.
+    handler.emit(record)

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
+uipath-ipc = false
 uipath-core = false
 
 [[package]]
@@ -1152,13 +1153,27 @@ wheels = [
 ]
 
 [[package]]
+name = "uipath-ipc"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/6b/53d9725d6abd1dab447300a7f999332f530678e3fabd38fc31171a5a9a6f/uipath_ipc-2.5.2.tar.gz", hash = "sha256:d69c3d7c1ad1a25ef7f9f1d78c505f5d2ed7daa7227bb202404fa3d47e0ba12e", size = 86360, upload-time = "2026-07-24T09:44:35.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/eb/6def505a0d351119da27b342c11eb0767a31a7f100022d35e349c5194eb3/uipath_ipc-2.5.2-py3-none-any.whl", hash = "sha256:617f25f35377d87956165a875b0966a3cd69ae6724fcd533c93a7a6a9460fc4f", size = 50345, upload-time = "2026-07-24T09:44:33.7Z" },
+]
+
+[[package]]
 name = "uipath-runtime"
-version = "0.13.4"
+version = "0.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
+]
+
+[package.optional-dependencies]
+ipc = [
+    { name = "uipath-ipc" },
 ]
 
 [package.dev-dependencies]
@@ -1174,14 +1189,17 @@ dev = [
     { name = "pytest-trio" },
     { name = "ruff" },
     { name = "rust-just" },
+    { name = "uipath-ipc" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "chardet", specifier = ">=5.2.0,<8.0" },
     { name = "uipath-core", specifier = ">=0.5.31,<0.6.0" },
+    { name = "uipath-ipc", marker = "extra == 'ipc'", specifier = ">=2.5.1,<2.6.0" },
     { name = "vadersentiment", specifier = ">=3.3.2,<4.0" },
 ]
+provides-extras = ["ipc"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1196,6 +1214,7 @@ dev = [
     { name = "pytest-trio", specifier = ">=0.8.0" },
     { name = "ruff", specifier = ">=0.9.4" },
     { name = "rust-just", specifier = ">=1.39.0" },
+    { name = "uipath-ipc", specifier = ">=2.5.1,<2.6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Add a `jobapi` package that streams a job's execution logs to the Robot handler over **uipath-ipc** instead of `execution.log`, for both non-pooled and pooled serverless executors. **Logs only** — the result stays on `output.json` (kept off-heap by `split_output_arguments`).

## Pieces

- `contract.py` — `IIpcLogSink` (`SendLog`) + `JobLogDto{Message, LogLevel}`, mirroring the .NET side.
- `client.py` — `IpcJobApiClient`: the non-pooled per-job client (private asyncio thread, Proactor on Windows, FIFO queue with retry/mute).
- `pooled.py` + `log_handler.py` — a process-global `PooledLogSink` and `PooledIpcSendLogHandler` for the pooled server, which owns the CoreIPC callback one layer up.
- `context.py` — use the IPC handler when `UIPATH_JOB_API_IPC_ENDPOINT` + `UIPATH_JOB_ID` are set (non-pooled), or the pooled sink when only `UIPATH_JOB_ID` is set and a sink is registered; `execution.log` is suppressed in both. Result unchanged.

Optional `[ipc]` extra (`uipath-ipc`). Version `0.13.4 → 0.13.5`.

## Related PRs — one endeavor

- hdens (handler side): UiPath/hdens#8031
- uipath-python (pooled `uipath server`): UiPath/uipath-python#1883

Merge order: **this PR → uipath-python → hdens.**

## Testing

Full suite green (450 tests incl. a real named-pipe round-trip); ruff/format/mypy clean.

## Jira

Tracking ticket: **ROBO-5980**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
